### PR TITLE
Fix admin URL collision, milestone edit template, and document form e…

### DIFF
--- a/fdk_cz/forms/project.py
+++ b/fdk_cz/forms/project.py
@@ -104,7 +104,7 @@ class document_form(forms.ModelForm):
         project_id = kwargs.pop('project_id', None)
         super().__init__(*args, **kwargs)
         if project_id:
-            self.fields['category'].queryset = category.objects.filter(project_id=project_id)
+            self.fields['category'].queryset = ProjectCategory.objects.filter(project_id=project_id)
 
 
 

--- a/fdk_cz/templates/project/edit_milestone.html
+++ b/fdk_cz/templates/project/edit_milestone.html
@@ -14,7 +14,7 @@
       <!-- Název -->
       <div class="form-group mb-4">
         <label for="id_title" class="block text-sm font-medium text-gray-700">Název milníku <span class="text-red-600">*</span></label>
-        {{ form.title|as_widget(attrs={'class': 'w-full p-2 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500'}) }}
+        <input type="text" name="title" id="id_title" value="{{ form.title.value|default:'' }}" class="w-full p-2 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500" required>
         {% if form.title.errors %}
           <p class="text-red-600 text-sm mt-1">{{ form.title.errors|join:", " }}</p>
         {% endif %}
@@ -23,7 +23,7 @@
       <!-- Popis -->
       <div class="form-group mb-4">
         <label for="id_description" class="block text-sm font-medium text-gray-700">Popis</label>
-        {{ form.description|as_widget(attrs={'class': 'w-full p-2 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500'}) }}
+        <textarea name="description" id="id_description" rows="4" class="w-full p-2 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500">{{ form.description.value|default:'' }}</textarea>
         {% if form.description.errors %}
           <p class="text-red-600 text-sm mt-1">{{ form.description.errors|join:", " }}</p>
         {% endif %}
@@ -32,7 +32,7 @@
       <!-- Termín dokončení -->
       <div class="form-group mb-4">
         <label for="id_due_date" class="block text-sm font-medium text-gray-700">Termín dokončení</label>
-        {{ form.due_date|as_widget(attrs={'type': 'date', 'class': 'w-full p-2 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500'}) }}
+        <input type="date" name="due_date" id="id_due_date" value="{{ form.due_date.value|date:'Y-m-d' }}" class="w-full p-2 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500">
         {% if form.due_date.errors %}
           <p class="text-red-600 text-sm mt-1">{{ form.due_date.errors|join:", " }}</p>
         {% endif %}

--- a/fdk_cz/urls.py
+++ b/fdk_cz/urls.py
@@ -93,10 +93,10 @@ urlpatterns = (
     path('predplatne/<int:subscription_id>/obnovit/', subscription.renew_subscription, name='renew_subscription'),
 
     # Subscription Admin URLs
-    path('admin/moduly/', subscription.admin_modules, name='admin_modules'),
-    path('admin/modul/<int:module_id>/upravit/', subscription.admin_edit_module, name='admin_edit_module'),
-    path('admin/priradit-modul/', subscription.admin_assign_module, name='admin_assign_module'),
-    path('admin/predplatne/', subscription.admin_subscriptions, name='admin_subscriptions'),
+    path('spravce/moduly/', subscription.admin_modules, name='admin_modules'),
+    path('spravce/modul/<int:module_id>/upravit/', subscription.admin_edit_module, name='admin_edit_module'),
+    path('spravce/priradit-modul/', subscription.admin_assign_module, name='admin_assign_module'),
+    path('spravce/predplatne/', subscription.admin_subscriptions, name='admin_subscriptions'),
 
     # Auth paths
     path('prihlaseni/', login, name='login_cs'),


### PR DESCRIPTION
…rrors

- Changed admin URLs from /admin/ to /spravce/ to avoid collision with Django's built-in admin
- Fixed edit_milestone.html: removed invalid 'as_widget' filter, replaced with proper HTML inputs
- Fixed document_form in forms/project.py: changed 'category' to 'ProjectCategory' to resolve NameError
- All form fields now render correctly with proper CSS classes