### PR TITLE
Fix grant system: visibility, permissions, and application creation

### DIFF
--- a/fdk_cz/urls.py
+++ b/fdk_cz/urls.py
@@ -128,7 +128,7 @@ urlpatterns = (
     # 📝 Žádosti
     path('dotace/zadosti/', application_list, name='application_list'),
     path('dotace/zadost/<int:application_id>/', application_detail, name='application_detail'),
-    path('dotace/zadost/novy/<int:grant_id>/', application_create, name='application_create'),
+    path('dotace/zadost/novy/<int:call_id>/', application_create, name='application_create'),
     path('dotace/zadost/<int:application_id>/edit/', application_edit, name='application_edit'),
     path('dotace/zadost/<int:application_id>/smazat/', application_delete, name='application_delete'),
 

--- a/fdk_cz/views/grants.py
+++ b/fdk_cz/views/grants.py
@@ -39,7 +39,12 @@ def program_detail(request, program_id):
 
 @login_required
 def program_create(request):
-    """Vytvoření nového programu"""
+    """Vytvoření nového programu - pouze pro superadminy"""
+    # Kontrola oprávnění - pouze superadmin může vytvářet programy
+    if not request.user.is_superuser:
+        messages.error(request, "Nemáte oprávnění k vytvoření programu. Pouze superadmin může vytvářet nové programy.")
+        return redirect("program_list")
+
     if request.method == "POST":
         name = request.POST.get("name")
         provider = request.POST.get("provider")
@@ -64,7 +69,12 @@ def program_create(request):
 
 @login_required
 def program_edit(request, program_id):
-    """Úprava programu"""
+    """Úprava programu - pouze pro superadminy"""
+    # Kontrola oprávnění - pouze superadmin může upravovat programy
+    if not request.user.is_superuser:
+        messages.error(request, "Nemáte oprávnění k úpravě programu. Pouze superadmin může upravovat programy.")
+        return redirect("program_detail", program_id=program_id)
+
     program = get_object_or_404(GrantProgram, pk=program_id)
     if request.method == "POST":
         program.name = request.POST.get("name", program.name)
@@ -93,8 +103,16 @@ def grant_list(request):
     if type_filter:
         grants = grants.filter(type=type_filter)
 
+    # Rozdělení dotací podle typu pro zobrazení v template
+    active_dotace = grants.filter(type='dotace')
+    active_granty = grants.filter(type='grant')
+    active_grants_count = grants.count()
+
     context = {
         "grants": grants,
+        "active_dotace": active_dotace,
+        "active_granty": active_granty,
+        "active_grants_count": active_grants_count,
         "providers": GrantCall.objects.values_list("provider", flat=True).distinct(),
         "types": GrantCall._meta.get_field("type").choices,
     }
@@ -124,7 +142,12 @@ def grant_detail(request, grant_id):
 
 @login_required
 def grant_create(request, program_id=None):
-    """Vytvoření nové výzvy / dotace"""
+    """Vytvoření nové výzvy / dotace - pouze pro superadminy"""
+    # Kontrola oprávnění - pouze superadmin může vytvářet dotace
+    if not request.user.is_superuser:
+        messages.error(request, "Nemáte oprávnění k vytvoření dotace. Pouze superadmin může vytvářet nové dotace.")
+        return redirect("grant_list")
+
     program = None
     if program_id:
         program = get_object_or_404(GrantProgram, pk=program_id)
@@ -160,7 +183,12 @@ def grant_create(request, program_id=None):
 
 @login_required
 def grant_edit(request, grant_id):
-    """Editace výzvy / dotace"""
+    """Editace výzvy / dotace - pouze pro superadminy"""
+    # Kontrola oprávnění - pouze superadmin může upravovat dotace
+    if not request.user.is_superuser:
+        messages.error(request, "Nemáte oprávnění k úpravě dotace. Pouze superadmin může upravovat dotace.")
+        return redirect("grant_detail", grant_id=grant_id)
+
     grant = get_object_or_404(GrantCall, pk=grant_id)
     if request.method == "POST":
         grant.title = request.POST.get("title", grant.title)
@@ -180,7 +208,12 @@ def grant_edit(request, grant_id):
 
 @login_required
 def grant_delete(request, grant_id):
-    """Smazání dotace"""
+    """Smazání dotace - pouze pro superadminy"""
+    # Kontrola oprávnění - pouze superadmin může mazat dotace
+    if not request.user.is_superuser:
+        messages.error(request, "Nemáte oprávnění ke smazání dotace. Pouze superadmin může mazat dotace.")
+        return redirect("grant_detail", grant_id=grant_id)
+
     grant = get_object_or_404(GrantCall, pk=grant_id)
     if request.method == "POST":
         grant.delete()


### PR DESCRIPTION
This commit resolves three critical issues with the grant system:

**1. Fixed Grants Not Showing on Main Page**
Problem: Grants were created but not visible on grant_list page Root Cause: Template expects `active_dotace` and `active_granty` variables,
  but view only passed generic `grants` variable
Solution:
  - Split grants by type in grant_list view
  - Added active_dotace (type='dotace')
  - Added active_granty (type='grant')
  - Added active_grants_count for stats File: fdk_cz/views/grants.py

**2. Fixed Application Creation TypeError**
Problem: TypeError - application_create() got unexpected keyword 'grant_id' Root Cause: URL pattern used `<int:grant_id>` but view function expected `call_id`
  (GrantCall model's primary key is call_id, not grant_id)
Solution: Changed URL pattern to use `<int:call_id>` instead File: fdk_cz/urls.py line 131

**3. Added Superadmin-Only Permissions**
Problem: All authenticated users could create/edit/delete grants and programs Requirement: Only superadmin should manage grants; regular users only apply Solution: Added `is_superuser` checks to:
  - program_create() - Only superadmin can create programs
  - program_edit() - Only superadmin can edit programs
  - grant_create() - Only superadmin can create grants
  - grant_edit() - Only superadmin can edit grants
  - grant_delete() - Only superadmin can delete grants

All unauthorized attempts redirect with error message Regular users can still:
  - View grant lists
  - View grant details
  - Create applications (apply to grants)
  - Manage their own applications

File: fdk_cz/views/grants.py (5 functions updated)

This ensures proper access control and fixes the grant visibility issue.