### PR TITLE
Implement module visibility preferences and fix project task view

### DIFF
--- a/fdk_cz/models.py
+++ b/fdk_cz/models.py
@@ -1133,6 +1133,31 @@ class ModuleUsage(models.Model):
         return f"{self.user.username} - {self.module.name} - {self.action}"
 
 
+class UserModulePreference(models.Model):
+    """Uživatelské preference pro zobrazení modulů v menu (zapnout/vypnout)"""
+    preference_id = models.AutoField(primary_key=True, db_column='preference_id')
+
+    user = models.ForeignKey(User, on_delete=models.CASCADE, related_name='module_preferences', db_column='user_id')
+    module = models.ForeignKey(Module, on_delete=models.CASCADE, related_name='user_preferences', db_column='module_id')
+
+    # Zobrazovat v menu?
+    is_visible = models.BooleanField(default=True, db_column='is_visible')
+
+    # Pořadí v menu (pro uživatelské seřazení)
+    display_order = models.IntegerField(default=0, db_column='display_order')
+
+    created_at = models.DateTimeField(auto_now_add=True, db_column='created_at')
+    updated_at = models.DateTimeField(auto_now=True, db_column='updated_at')
+
+    class Meta:
+        db_table = 'FDK_user_module_preference'
+        unique_together = ('user', 'module')
+        ordering = ['display_order', 'module__order']
+
+    def __str__(self):
+        return f"{self.user.username} - {self.module.display_name} ({'✓' if self.is_visible else '✗'})"
+
+
 # -------------------------------------------------------------------
 #                    B2B MANAGEMENT
 # -------------------------------------------------------------------

--- a/fdk_cz/templates/project/detail_project.html
+++ b/fdk_cz/templates/project/detail_project.html
@@ -16,12 +16,55 @@ Projekt vedený uživatelem <strong>{{ project.owner.username }}</strong> &middo
       <h2 class="text-xl font-semibold text-gray-800">✅ Úkoly projektu</h2>
       <div class="flex gap-3">
         <a href="novy-ukol/" class="btn btn-primary">＋ Nový úkol</a>
-        <button id="toggleView" class="btn btn-outline">📋 Přepnout zobrazení</button>
+        <button id="toggleView" class="btn btn-outline">📊 Zobrazit Kanban</button>
       </div>
     </div>
 
-    <!-- Sloupcové zobrazení (defaultní) -->
-    <div id="task_columns" class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <!-- Tabulkové zobrazení (výchozí) -->
+    <div id="task_table">
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Název</th>
+            <th>Status</th>
+            <th class="hidden md:table-cell">Priorita</th>
+            <th>Přiřazeno</th>
+            <th class="hidden md:table-cell">Kategorie</th>
+            <th class="text-right">Akce</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for task in tasks_to_do %}
+          <tr>
+            <td>
+              <a href="{% url 'detail_task' task.task_id %}"><strong>{{ task.title }}</strong></a>
+            </td>
+            <td>
+              <span class="px-2 py-1 rounded text-xs font-medium
+                {% if task.status == 'Hotovo' %}bg-green-100 text-green-700
+                {% elif task.status == 'Probíhá' %}bg-yellow-100 text-yellow-800
+                {% else %}bg-gray-100 text-gray-700{% endif %}">
+                {{ task.status|default:"Nezahájeno" }}
+              </span>
+            </td>
+            <td class="hidden md:table-cell">{{ task.priority }}</td>
+            <td>{{ task.assigned.username|default:"–" }}</td>
+            <td class="hidden md:table-cell">{{ task.category.name|default:"–" }}</td>
+            <td class="text-right">
+              <div class="data-table-actions">
+                <a href="{% url 'detail_task' task.task_id %}">👁️ Detail</a>
+              </div>
+            </td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="6" class="data-table-empty">Žádné úkoly k zobrazení</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Sloupcové zobrazení (kanban) -->
+    <div id="task_columns" class="hidden grid grid-cols-1 md:grid-cols-3 gap-4">
       <!-- Nezahájeno / Ke zpracování -->
       <div class="bg-gradient-to-br from-gray-50 to-gray-100 border-2 border-gray-200 rounded-lg p-4">
         <h3 class="font-bold text-gray-700 mb-3 flex items-center">
@@ -102,49 +145,6 @@ Projekt vedený uživatelem <strong>{{ project.owner.username }}</strong> &middo
           {% endfor %}
         </div>
       </div>
-    </div>
-
-    <!-- Tabulkové zobrazení -->
-    <div id="task_table" class="hidden">
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Název</th>
-            <th>Status</th>
-            <th class="hidden md:table-cell">Priorita</th>
-            <th>Přiřazeno</th>
-            <th class="hidden md:table-cell">Kategorie</th>
-            <th class="text-right">Akce</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for task in tasks_to_do %}
-          <tr>
-            <td>
-              <a href="{% url 'detail_task' task.task_id %}"><strong>{{ task.title }}</strong></a>
-            </td>
-            <td>
-              <span class="px-2 py-1 rounded text-xs font-medium
-                {% if task.status == 'Hotovo' %}bg-green-100 text-green-700
-                {% elif task.status == 'Probíhá' %}bg-yellow-100 text-yellow-800
-                {% else %}bg-gray-100 text-gray-700{% endif %}">
-                {{ task.status|default:"Nezahájeno" }}
-              </span>
-            </td>
-            <td class="hidden md:table-cell">{{ task.priority }}</td>
-            <td>{{ task.assigned.username|default:"–" }}</td>
-            <td class="hidden md:table-cell">{{ task.category.name|default:"–" }}</td>
-            <td class="text-right">
-              <div class="data-table-actions">
-                <a href="{% url 'detail_task' task.task_id %}">👁️ Detail</a>
-              </div>
-            </td>
-          </tr>
-          {% empty %}
-          <tr><td colspan="6" class="data-table-empty">Žádné úkoly k zobrazení</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
     </div>
   </div>
 
@@ -385,11 +385,13 @@ document.addEventListener('DOMContentLoaded', () => {
       taskTable.classList.toggle('hidden');
       taskColumns.classList.toggle('hidden');
 
-      // Update button text
-      if (taskTable.classList.contains('hidden')) {
-        toggleBtn.textContent = '📋 Přepnout zobrazení';
+      // Update button text based on current view
+      if (taskColumns.classList.contains('hidden')) {
+        // Showing table view
+        toggleBtn.textContent = '📊 Zobrazit Kanban';
       } else {
-        toggleBtn.textContent = '📊 Přepnout zobrazení';
+        // Showing kanban view
+        toggleBtn.textContent = '📋 Zobrazit tabulku';
       }
     });
   } else {

--- a/fdk_cz/templates/user/settings.html
+++ b/fdk_cz/templates/user/settings.html
@@ -214,11 +214,11 @@
       <!-- Helper Sidebar (1/3 width) -->
       <div class="content-card" style="background: #f8fafc;">
         <h3>&#128161; {% trans "Pomocník" %}</h3>
-        
+
         <p style="color: #64748b; margin-bottom: 1.5rem;">
           {% trans "Zadejte své aktuální údaje do formuláře a uložte změny." %}
         </p>
-        
+
         <p style="color: #64748b; margin-bottom: 2rem;">
           {% trans "Ujistěte se, že máte aktuální email pro obnovu hesla nebo kontaktování podpory." %}
         </p>
@@ -252,6 +252,46 @@
             <a href="https://fdk.cz" style="color: #64748b; text-decoration: none;">FDK.cz</a>
           </p>
         </div>
+      </div>
+    </div>
+
+    <!-- Module Management Section -->
+    <div class="content-card" style="margin-top: 2rem;">
+      <h3>&#128268; Správa modulů v menu</h3>
+      <p class="text-gray-600 mb-4">Zapněte nebo vypněte moduly, které chcete vidět v navigačním menu pro lepší přehlednost.</p>
+
+      <div class="space-y-2">
+        {% for item in modules_with_prefs %}
+        <div class="flex items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-200 hover:bg-gray-100 transition">
+          <div class="flex items-center gap-3">
+            <span class="text-2xl">{{ item.module.icon|default:"📦" }}</span>
+            <div>
+              <div class="font-semibold text-gray-800">{{ item.module.display_name }}</div>
+              <div class="text-sm text-gray-500">{{ item.module.short_description|default:item.module.description|truncatewords:10 }}</div>
+              {% if item.module.is_free %}
+                <span class="inline-block text-xs bg-green-100 text-green-700 px-2 py-1 rounded mt-1">Zdarma</span>
+              {% endif %}
+            </div>
+          </div>
+
+          <form method="POST" action="{% url 'toggle_module_visibility' item.module.module_id %}" style="margin: 0;">
+            {% csrf_token %}
+            <button type="submit" class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 {{ item.is_visible|yesno:'bg-blue-600,bg-gray-300' }}">
+              <span class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform {{ item.is_visible|yesno:'translate-x-6,translate-x-1' }}"></span>
+            </button>
+          </form>
+        </div>
+        {% empty %}
+        <div class="text-center py-8 bg-gray-50 rounded-lg">
+          <p class="text-gray-500">Žádné moduly k dispozici.</p>
+        </div>
+        {% endfor %}
+      </div>
+
+      <div class="mt-4 p-4 bg-blue-50 border-l-4 border-blue-400 rounded">
+        <p class="text-sm text-blue-800">
+          <strong>💡 Tip:</strong> Vypnuté moduly zůstávají dostupné přes vyhledávání, jen se nebudou zobrazovat v navigačním menu.
+        </p>
       </div>
     </div>
 

--- a/fdk_cz/urls.py
+++ b/fdk_cz/urls.py
@@ -29,7 +29,7 @@ from fdk_cz.views.project import create_category, create_document, create_task, 
 
 from fdk_cz.views.test import  create_test, create_test_error, create_test_result, create_test_type, delete_test_error, detail_test_error, edit_test, edit_test_error,  edit_test_type, list_test_errors, get_test_types, list_tests, list_test_results, list_test_types
 
-from fdk_cz.views.user import login, logout, user_profile, registration, user_settings
+from fdk_cz.views.user import login, logout, user_profile, registration, user_settings, toggle_module_visibility
 
 from fdk_cz.views.warehouse import (
     all_stores,
@@ -102,9 +102,10 @@ urlpatterns = (
     path('prihlaseni/', login, name='login_cs'),
     path('odhlaseni/', logout, name='logout_cs'),
     path('registrace/', registration, name='registration_cs'),
-    path('profil/', user_profile, name='user_profile'),   
-    path('profil/nastaveni/', user_settings, name='user_settings'),   
-         
+    path('profil/', user_profile, name='user_profile'),
+    path('profil/nastaveni/', user_settings, name='user_settings'),
+    path('profil/nastaveni/modul/<int:module_id>/toggle/', toggle_module_visibility, name='toggle_module_visibility'),
+
     # EN
     path('login/', login, name='login_en'),
     path('logout/', logout, name='logout_en'),  


### PR DESCRIPTION
Module Management System:
- Added UserModulePreference model for managing module visibility in menu
- Created module settings page in user settings with toggle switches
- Added toggle_module_visibility view and URL endpoint
- Users can now hide/show modules in navigation for better clarity
- Default all modules visible, toggle to hide unused ones

Project Detail View Improvements:
- Fixed default view: now shows table view by default (was Kanban)
- Added "Zobrazit Kanban" / "Zobrazit tabulku" toggle button
- Improved button text to clearly indicate current and next view
- Kanban columns remain styled and fully functional when toggled

User Settings Template:
- Added comprehensive module management section
- Toggle switches for each module with visual feedback
- Shows module icon, name, description, and "Zdarma" badges
- Informative tip about module visibility