### PR TITLE
Add comprehensive documentation system and fix task view toggle

### DIFF
--- a/fdk_cz/models.py
+++ b/fdk_cz/models.py
@@ -1680,3 +1680,62 @@ class Asset(models.Model):
 
     def __str__(self):
         return f"{self.name} ({self.asset_number})"
+
+
+# -------------------------------------------------------------------
+#                    HELP & DOCUMENTATION SYSTEM
+# -------------------------------------------------------------------
+
+class HelpArticle(models.Model):
+    """Dokumentace a nápověda pro systém FDK.cz"""
+    article_id = models.AutoField(primary_key=True, db_column='article_id')
+
+    # Základní údaje
+    title = models.CharField(max_length=255, db_column='title')
+    slug = models.SlugField(max_length=255, unique=True, db_column='slug')
+    content = models.TextField(db_column='content', help_text='Markdown formátovaný text')
+
+    # Kategorizace
+    CATEGORY_CHOICES = [
+        ('intro', 'Obecný úvod'),
+        ('module', 'Dokumentace modulu'),
+        ('technical', 'Technická dokumentace'),
+        ('faq', 'Často kladené otázky')
+    ]
+    category = models.CharField(max_length=20, choices=CATEGORY_CHOICES, db_column='category')
+
+    # Propojení s modulem (volitelné)
+    module = models.ForeignKey('Module', on_delete=models.SET_NULL, null=True, blank=True,
+                               related_name='help_articles', db_column='module_id',
+                               help_text='Modul, ke kterému se článek vztahuje')
+
+    # Řazení a viditelnost
+    order = models.IntegerField(default=0, db_column='order', help_text='Pořadí zobrazení (nižší = dříve)')
+    is_published = models.BooleanField(default=True, db_column='is_published')
+    is_technical = models.BooleanField(default=False, db_column='is_technical',
+                                      help_text='Viditelné pouze pro administrátory a testery')
+
+    # Metadata
+    created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True,
+                                  related_name='created_help_articles', db_column='created_by_id')
+    created_at = models.DateTimeField(auto_now_add=True, db_column='created_at')
+    updated_at = models.DateTimeField(auto_now=True, db_column='updated_at')
+
+    # SEO a vyhledávání
+    meta_description = models.CharField(max_length=255, null=True, blank=True, db_column='meta_description')
+    keywords = models.CharField(max_length=500, null=True, blank=True, db_column='keywords',
+                                help_text='Klíčová slova oddělená čárkami')
+
+    class Meta:
+        db_table = 'FDK_help_article'
+        ordering = ['order', 'title']
+        indexes = [
+            models.Index(fields=['category', 'is_published']),
+            models.Index(fields=['module', 'is_published']),
+        ]
+
+    def __str__(self):
+        return f"{self.title} ({self.get_category_display()})"
+
+    def get_absolute_url(self):
+        return f"/napoveda/{self.slug}/"

--- a/fdk_cz/templates/base.html
+++ b/fdk_cz/templates/base.html
@@ -81,6 +81,7 @@
           <a href="{% url 'list_tests' %}" class="nav-item"><span class="nav-icon">&#129514;</span> Testování</a>
           <a href="{% url 'all_stores' %}" class="nav-item"><span class="nav-icon">&#128230;</span> Sklad</a>
           <a href="{% url 'law_list' %}" class="nav-item"><span class="nav-icon">&#128220;</span> Zákony</a>
+          <a href="{% url 'help_index' %}" class="nav-item"><span class="nav-icon">&#128218;</span> Dokumentace</a>
         </div>
 
         {% if user.is_superuser or user.is_staff %}

--- a/fdk_cz/templates/help/add.html
+++ b/fdk_cz/templates/help/add.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}Přidat článek | Nápověda | FDK.cz{% endblock %}
+{% block header_title %}＋ Přidat nový článek nápovědy{% endblock %}
+{% block header_subtitle %}
+Vytvoření nového článku dokumentace pro uživatele
+{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto">
+
+  <div class="content-card">
+    <form method="POST">
+      {% csrf_token %}
+
+      <!-- Title -->
+      <div class="form-group">
+        <label for="title" class="form-label">Název článku <span class="required">*</span></label>
+        <input type="text" name="title" id="title" class="form-control" required placeholder="Např. Úvod do správy projektů">
+      </div>
+
+      <!-- Slug -->
+      <div class="form-group">
+        <label for="slug" class="form-label">URL slug</label>
+        <input type="text" name="slug" id="slug" class="form-control" placeholder="uvod-do-spravy-projektu (nechte prázdné pro automatické generování)">
+        <div class="form-help">URL friendly verze názvu. Pokud necháte prázdné, vygeneruje se automaticky.</div>
+      </div>
+
+      <!-- Category -->
+      <div class="form-group">
+        <label for="category" class="form-label">Kategorie <span class="required">*</span></label>
+        <select name="category" id="category" class="form-control" required>
+          <option value="">-- Vyberte kategorii --</option>
+          {% for value, label in categories %}
+          <option value="{{ value }}">{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <!-- Module (optional) -->
+      <div class="form-group">
+        <label for="module" class="form-label">Modul (volitelné)</label>
+        <select name="module" id="module" class="form-control">
+          <option value="">-- Bez modulu --</option>
+          {% for module in modules %}
+          <option value="{{ module.module_id }}">{{ module.display_name }}</option>
+          {% endfor %}
+        </select>
+        <div class="form-help">Pokud se článek vztahuje ke konkrétnímu modulu, vyberte ho zde.</div>
+      </div>
+
+      <!-- Content -->
+      <div class="form-group">
+        <label for="content" class="form-label">Obsah (Markdown) <span class="required">*</span></label>
+        <textarea name="content" id="content" rows="20" class="form-control" required placeholder="# Nadpis
+
+Základní text článku...
+
+## Podnadpis
+
+- Odrážka 1
+- Odrážka 2
+
+**Tučný text** a *kurzíva*"></textarea>
+        <div class="form-help">Podporuje Markdown formátování (nadpisy, seznamy, tučný text, odkazy atd.)</div>
+      </div>
+
+      <!-- Meta Description -->
+      <div class="form-group">
+        <label for="meta_description" class="form-label">Krátký popis</label>
+        <input type="text" name="meta_description" id="meta_description" class="form-control" maxlength="255" placeholder="Stručný popis pro zobrazení v seznamu">
+      </div>
+
+      <!-- Keywords -->
+      <div class="form-group">
+        <label for="keywords" class="form-label">Klíčová slova</label>
+        <input type="text" name="keywords" id="keywords" class="form-control" placeholder="projekt, úkol, management, dokumentace">
+        <div class="form-help">Oddělené čárkami pro lepší vyhledávání</div>
+      </div>
+
+      <!-- Order -->
+      <div class="form-group">
+        <label for="order" class="form-label">Pořadí zobrazení</label>
+        <input type="number" name="order" id="order" class="form-control" value="0" min="0">
+        <div class="form-help">Nižší číslo = vyšší pozice v seznamu</div>
+      </div>
+
+      <!-- Flags -->
+      <div class="form-group">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="is_published" checked class="w-4 h-4">
+          <span>Publikováno (viditelné pro uživatele)</span>
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="is_technical" class="w-4 h-4">
+          <span>🔧 Technická dokumentace (viditelné pouze pro administrátory a testery)</span>
+        </label>
+      </div>
+
+      <!-- Buttons -->
+      <div class="flex justify-end gap-3 pt-4 border-t border-gray-200">
+        <a href="{% url 'help_index' %}" class="btn btn-outline">Zrušit</a>
+        <button type="submit" class="btn btn-primary">💾 Vytvořit článek</button>
+      </div>
+    </form>
+  </div>
+
+</div>
+
+<script>
+// Auto-generate slug from title
+document.getElementById('title').addEventListener('input', function() {
+  const slugInput = document.getElementById('slug');
+  if (!slugInput.value || slugInput.dataset.auto !== 'false') {
+    const title = this.value;
+    const slug = title
+      .toLowerCase()
+      .normalize('NFD').replace(/[\u0300-\u036f]/g, '') // Remove diacritics
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    slugInput.value = slug;
+    slugInput.dataset.auto = 'true';
+  }
+});
+
+document.getElementById('slug').addEventListener('input', function() {
+  this.dataset.auto = 'false';
+});
+</script>
+{% endblock %}

--- a/fdk_cz/templates/help/delete.html
+++ b/fdk_cz/templates/help/delete.html
@@ -1,0 +1,60 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}Smazat {{ article.title }} | Nápověda | FDK.cz{% endblock %}
+{% block header_title %}🗑️ Smazat článek{% endblock %}
+{% block header_subtitle %}
+Potvrzení smazání
+{% endblock %}
+
+{% block content %}
+<div class="max-w-2xl mx-auto">
+
+  <div class="content-card bg-red-50 border-2 border-red-200">
+    <div class="text-center mb-6">
+      <div class="text-6xl mb-4">⚠️</div>
+      <h2 class="text-2xl font-bold text-gray-800 mb-2">Opravdu chcete smazat tento článek?</h2>
+      <p class="text-gray-600">Tato akce je nevratná.</p>
+    </div>
+
+    <!-- Article Info -->
+    <div class="bg-white rounded-lg p-6 mb-6 border border-red-200">
+      <h3 class="text-xl font-semibold text-gray-800 mb-2">{{ article.title }}</h3>
+
+      <div class="space-y-2 text-sm text-gray-600">
+        <div>
+          <strong>Kategorie:</strong> {{ article.get_category_display }}
+        </div>
+        {% if article.module %}
+        <div>
+          <strong>Modul:</strong> {{ article.module.display_name }}
+        </div>
+        {% endif %}
+        <div>
+          <strong>URL:</strong> /napoveda/{{ article.slug }}/
+        </div>
+        {% if article.created_by %}
+        <div>
+          <strong>Vytvořil:</strong> {{ article.created_by.username }}
+        </div>
+        {% endif %}
+        <div>
+          <strong>Vytvořeno:</strong> {{ article.created_at|date:"d.m.Y H:i" }}
+        </div>
+      </div>
+    </div>
+
+    <!-- Confirmation Form -->
+    <form method="POST">
+      {% csrf_token %}
+
+      <div class="flex justify-center gap-4">
+        <a href="{% url 'help_detail' article.slug %}" class="btn btn-outline">✖ Zrušit</a>
+        <button type="submit" class="btn btn-primary bg-red-600 hover:bg-red-700 border-red-600">🗑️ Ano, smazat článek</button>
+      </div>
+    </form>
+
+  </div>
+
+</div>
+{% endblock %}

--- a/fdk_cz/templates/help/detail.html
+++ b/fdk_cz/templates/help/detail.html
@@ -1,0 +1,165 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{{ article.title }} | Nápověda | FDK.cz{% endblock %}
+{% block header_title %}{{ article.title }}{% endblock %}
+{% block header_subtitle %}
+{% if article.module %}
+Modul: {{ article.module.display_name }}
+{% else %}
+{{ article.get_category_display }}
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto">
+
+  <!-- Breadcrumb -->
+  <div class="mb-6">
+    <nav class="flex items-center gap-2 text-sm text-gray-600">
+      <a href="{% url 'help_index' %}" class="hover:text-blue-600">📚 Nápověda</a>
+      <span>→</span>
+      <span class="text-gray-800 font-medium">{{ article.title }}</span>
+    </nav>
+  </div>
+
+  <!-- Article Content -->
+  <div class="content-card">
+    <!-- Header -->
+    <div class="flex justify-between items-start mb-6">
+      <div>
+        {% if article.is_technical %}
+        <span class="inline-block bg-yellow-100 text-yellow-800 text-xs font-semibold px-3 py-1 rounded-full mb-2">
+          🔧 Technická dokumentace
+        </span>
+        {% endif %}
+        {% if article.module %}
+        <div class="flex items-center gap-2 mb-2">
+          <span class="text-2xl">{{ article.module.icon|default:"📦" }}</span>
+          <span class="text-sm font-semibold text-gray-600">{{ article.module.display_name }}</span>
+        </div>
+        {% endif %}
+      </div>
+
+      {% if can_edit %}
+      <div class="flex gap-2">
+        <a href="{% url 'help_edit' article.slug %}" class="btn btn-outline">✏️ Upravit</a>
+        <a href="{% url 'help_delete' article.slug %}" class="btn btn-outline text-red-600 border-red-600 hover:bg-red-50">🗑️ Smazat</a>
+      </div>
+      {% endif %}
+    </div>
+
+    <!-- Content (Markdown rendered as HTML) -->
+    <div class="prose prose-lg max-w-none">
+      <div class="markdown-content">
+        {{ article.content|linebreaks }}
+      </div>
+    </div>
+
+    <!-- Metadata -->
+    <div class="mt-8 pt-6 border-t border-gray-200">
+      <div class="flex flex-wrap gap-4 text-sm text-gray-600">
+        <div>
+          <span class="font-semibold">Vytvořeno:</span> {{ article.created_at|date:"d.m.Y H:i" }}
+        </div>
+        {% if article.created_by %}
+        <div>
+          <span class="font-semibold">Autor:</span> {{ article.created_by.username }}
+        </div>
+        {% endif %}
+        {% if article.updated_at != article.created_at %}
+        <div>
+          <span class="font-semibold">Upraveno:</span> {{ article.updated_at|date:"d.m.Y H:i" }}
+        </div>
+        {% endif %}
+      </div>
+    </div>
+
+    <!-- Keywords -->
+    {% if article.keywords %}
+    <div class="mt-4 flex flex-wrap gap-2">
+      {% for keyword in article.keywords.split:',' %}
+      <span class="inline-block bg-gray-100 text-gray-700 text-xs px-3 py-1 rounded-full">
+        {{ keyword|trim }}
+      </span>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </div>
+
+  <!-- Back button -->
+  <div class="mt-6">
+    <a href="{% url 'help_index' %}" class="btn btn-outline">← Zpět na přehled nápovědy</a>
+  </div>
+
+</div>
+
+<style>
+.markdown-content {
+  line-height: 1.8;
+}
+
+.markdown-content h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  color: #1e293b;
+}
+
+.markdown-content h2 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: #334155;
+}
+
+.markdown-content h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 1.25rem;
+  margin-bottom: 0.5rem;
+  color: #475569;
+}
+
+.markdown-content p {
+  margin-bottom: 1rem;
+  color: #64748b;
+}
+
+.markdown-content ul, .markdown-content ol {
+  margin-left: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.markdown-content li {
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content code {
+  background: #f1f5f9;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-family: 'Courier New', monospace;
+  font-size: 0.9em;
+}
+
+.markdown-content pre {
+  background: #1e293b;
+  color: #e2e8f0;
+  padding: 1rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+
+.markdown-content blockquote {
+  border-left: 4px solid #3b82f6;
+  padding-left: 1rem;
+  margin-left: 0;
+  color: #64748b;
+  font-style: italic;
+}
+</style>
+{% endblock %}

--- a/fdk_cz/templates/help/edit.html
+++ b/fdk_cz/templates/help/edit.html
@@ -1,0 +1,103 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}Upravit {{ article.title }} | Nápověda | FDK.cz{% endblock %}
+{% block header_title %}✏️ Upravit článek{% endblock %}
+{% block header_subtitle %}
+{{ article.title }}
+{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto">
+
+  <div class="content-card">
+    <form method="POST">
+      {% csrf_token %}
+
+      <!-- Title -->
+      <div class="form-group">
+        <label for="title" class="form-label">Název článku <span class="required">*</span></label>
+        <input type="text" name="title" id="title" class="form-control" required value="{{ article.title }}">
+      </div>
+
+      <!-- Slug -->
+      <div class="form-group">
+        <label for="slug" class="form-label">URL slug <span class="required">*</span></label>
+        <input type="text" name="slug" id="slug" class="form-control" required value="{{ article.slug }}">
+        <div class="form-help">URL friendly verze názvu.</div>
+      </div>
+
+      <!-- Category -->
+      <div class="form-group">
+        <label for="category" class="form-label">Kategorie <span class="required">*</span></label>
+        <select name="category" id="category" class="form-control" required>
+          {% for value, label in categories %}
+          <option value="{{ value }}" {% if article.category == value %}selected{% endif %}>{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <!-- Module (optional) -->
+      <div class="form-group">
+        <label for="module" class="form-label">Modul (volitelné)</label>
+        <select name="module" id="module" class="form-control">
+          <option value="">-- Bez modulu --</option>
+          {% for module in modules %}
+          <option value="{{ module.module_id }}" {% if article.module and article.module.module_id == module.module_id %}selected{% endif %}>
+            {{ module.display_name }}
+          </option>
+          {% endfor %}
+        </select>
+      </div>
+
+      <!-- Content -->
+      <div class="form-group">
+        <label for="content" class="form-label">Obsah (Markdown) <span class="required">*</span></label>
+        <textarea name="content" id="content" rows="20" class="form-control" required>{{ article.content }}</textarea>
+        <div class="form-help">Podporuje Markdown formátování</div>
+      </div>
+
+      <!-- Meta Description -->
+      <div class="form-group">
+        <label for="meta_description" class="form-label">Krátký popis</label>
+        <input type="text" name="meta_description" id="meta_description" class="form-control" maxlength="255" value="{{ article.meta_description|default:'' }}">
+      </div>
+
+      <!-- Keywords -->
+      <div class="form-group">
+        <label for="keywords" class="form-label">Klíčová slova</label>
+        <input type="text" name="keywords" id="keywords" class="form-control" value="{{ article.keywords|default:'' }}">
+        <div class="form-help">Oddělené čárkami</div>
+      </div>
+
+      <!-- Order -->
+      <div class="form-group">
+        <label for="order" class="form-label">Pořadí zobrazení</label>
+        <input type="number" name="order" id="order" class="form-control" value="{{ article.order }}" min="0">
+      </div>
+
+      <!-- Flags -->
+      <div class="form-group">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="is_published" {% if article.is_published %}checked{% endif %} class="w-4 h-4">
+          <span>Publikováno</span>
+        </label>
+      </div>
+
+      <div class="form-group">
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input type="checkbox" name="is_technical" {% if article.is_technical %}checked{% endif %} class="w-4 h-4">
+          <span>🔧 Technická dokumentace</span>
+        </label>
+      </div>
+
+      <!-- Buttons -->
+      <div class="flex justify-end gap-3 pt-4 border-t border-gray-200">
+        <a href="{% url 'help_detail' article.slug %}" class="btn btn-outline">Zrušit</a>
+        <button type="submit" class="btn btn-primary">💾 Uložit změny</button>
+      </div>
+    </form>
+  </div>
+
+</div>
+{% endblock %}

--- a/fdk_cz/templates/help/index.html
+++ b/fdk_cz/templates/help/index.html
@@ -1,0 +1,158 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}Nápověda | FDK.cz{% endblock %}
+{% block header_title %}📚 Nápověda a dokumentace{% endblock %}
+{% block header_subtitle %}
+Kompletní průvodce systémem FDK.cz pro efektivní řízení organizací
+{% endblock %}
+
+{% block content %}
+<div class="max-w-6xl mx-auto space-y-8">
+
+  <!-- Header Actions -->
+  {% if can_edit %}
+  <div class="flex justify-end mb-4">
+    <a href="{% url 'help_add' %}" class="btn btn-primary">＋ Přidat článek</a>
+  </div>
+  {% endif %}
+
+  <!-- Obecný úvod -->
+  {% if intro_articles %}
+  <div class="content-card">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+      <span class="text-3xl mr-3">🏠</span> Obecný úvod
+    </h2>
+    <p class="text-gray-600 mb-6">Základní informace o systému FDK.cz a jeho možnostech</p>
+
+    <div class="space-y-3">
+      {% for article in intro_articles %}
+      <a href="{% url 'help_detail' article.slug %}" class="block p-4 bg-gray-50 hover:bg-gray-100 rounded-lg border border-gray-200 transition">
+        <div class="flex justify-between items-start">
+          <div>
+            <h3 class="font-semibold text-gray-800 text-lg">{{ article.title }}</h3>
+            {% if article.meta_description %}
+            <p class="text-sm text-gray-600 mt-1">{{ article.meta_description }}</p>
+            {% endif %}
+          </div>
+          {% if can_edit %}
+          <div class="flex gap-2">
+            <a href="{% url 'help_edit' article.slug %}" class="text-blue-600 hover:text-blue-800 text-sm">✏️</a>
+            <a href="{% url 'help_delete' article.slug %}" class="text-red-600 hover:text-red-800 text-sm">🗑️</a>
+          </div>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Dokumentace modulů -->
+  {% if modules_with_articles %}
+  <div class="content-card">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+      <span class="text-3xl mr-3">📦</span> Dokumentace modulů
+    </h2>
+    <p class="text-gray-600 mb-6">Podrobný popis jednotlivých modulů a jejich funkcí</p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      {% for module, articles in modules_with_articles.items %}
+      <div class="bg-gray-50 rounded-lg border border-gray-200 p-4">
+        <div class="flex items-center gap-3 mb-3">
+          <span class="text-2xl">{{ module.icon|default:"📦" }}</span>
+          <h3 class="font-bold text-gray-800 text-lg">{{ module.display_name }}</h3>
+        </div>
+
+        <div class="space-y-2">
+          {% for article in articles %}
+          <a href="{% url 'help_detail' article.slug %}" class="block px-3 py-2 bg-white hover:bg-blue-50 rounded border border-gray-200 transition">
+            <div class="flex justify-between items-center">
+              <span class="text-gray-800">{{ article.title }}</span>
+              {% if can_edit %}
+              <div class="flex gap-1">
+                <a href="{% url 'help_edit' article.slug %}" class="text-blue-600 hover:text-blue-800 text-xs" onclick="event.stopPropagation();">✏️</a>
+              </div>
+              {% endif %}
+            </div>
+          </a>
+          {% endfor %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Často kladené otázky -->
+  {% if faq_articles %}
+  <div class="content-card">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+      <span class="text-3xl mr-3">❓</span> Často kladené otázky
+    </h2>
+
+    <div class="space-y-3">
+      {% for article in faq_articles %}
+      <a href="{% url 'help_detail' article.slug %}" class="block p-4 bg-gray-50 hover:bg-gray-100 rounded-lg border border-gray-200 transition">
+        <div class="flex justify-between items-start">
+          <h3 class="font-semibold text-gray-800">{{ article.title }}</h3>
+          {% if can_edit %}
+          <div class="flex gap-2">
+            <a href="{% url 'help_edit' article.slug %}" class="text-blue-600 hover:text-blue-800 text-sm">✏️</a>
+            <a href="{% url 'help_delete' article.slug %}" class="text-red-600 hover:text-red-800 text-sm">🗑️</a>
+          </div>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Technická dokumentace (jen pro administrátory a testery) -->
+  {% if technical_articles %}
+  <div class="content-card bg-yellow-50 border-2 border-yellow-300">
+    <h2 class="text-2xl font-bold text-gray-800 mb-4 flex items-center">
+      <span class="text-3xl mr-3">🔧</span> Technická dokumentace
+    </h2>
+    <p class="text-gray-600 mb-4">
+      <strong>⚠️ Viditelné pouze pro administrátory a testery</strong>
+    </p>
+
+    <div class="space-y-3">
+      {% for article in technical_articles %}
+      <a href="{% url 'help_detail' article.slug %}" class="block p-4 bg-white hover:bg-yellow-100 rounded-lg border border-yellow-200 transition">
+        <div class="flex justify-between items-start">
+          <div>
+            <h3 class="font-semibold text-gray-800">{{ article.title }}</h3>
+            {% if article.meta_description %}
+            <p class="text-sm text-gray-600 mt-1">{{ article.meta_description }}</p>
+            {% endif %}
+          </div>
+          {% if can_edit %}
+          <div class="flex gap-2">
+            <a href="{% url 'help_edit' article.slug %}" class="text-blue-600 hover:text-blue-800 text-sm">✏️</a>
+            <a href="{% url 'help_delete' article.slug %}" class="text-red-600 hover:text-red-800 text-sm">🗑️</a>
+          </div>
+          {% endif %}
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
+  <!-- Empty state -->
+  {% if not intro_articles and not modules_with_articles and not faq_articles and not technical_articles %}
+  <div class="content-card text-center py-12">
+    <div class="text-6xl mb-4">📚</div>
+    <h3 class="text-xl font-semibold text-gray-800 mb-2">Zatím zde není žádná dokumentace</h3>
+    <p class="text-gray-600 mb-4">Dokumentace se právě připravuje</p>
+    {% if can_edit %}
+    <a href="{% url 'help_add' %}" class="btn btn-primary">＋ Přidat první článek</a>
+    {% endif %}
+  </div>
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/fdk_cz/templates/index.html
+++ b/fdk_cz/templates/index.html
@@ -139,6 +139,10 @@
             <span class="nav-icon">&#128220;</span>
             Zákony
           </a>
+          <a href="{% url 'help_index' %}" class="nav-item {% if 'help' in request.resolver_match.url_name %}active{% endif %}">
+            <span class="nav-icon">&#128218;</span>
+            Dokumentace
+          </a>
         </div>
       </nav>
     </aside>

--- a/fdk_cz/templates/project/detail_project.html
+++ b/fdk_cz/templates/project/detail_project.html
@@ -64,7 +64,7 @@ Projekt vedený uživatelem <strong>{{ project.owner.username }}</strong> &middo
     </div>
 
     <!-- Sloupcové zobrazení (kanban) -->
-    <div id="task_columns" class="hidden grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div id="task_columns" style="display: none;" class="grid grid-cols-1 md:grid-cols-3 gap-4">
       <!-- Nezahájeno / Ke zpracování -->
       <div class="bg-gradient-to-br from-gray-50 to-gray-100 border-2 border-gray-200 rounded-lg p-4">
         <h3 class="font-bold text-gray-700 mb-3 flex items-center">
@@ -382,15 +382,17 @@ document.addEventListener('DOMContentLoaded', () => {
   if (toggleBtn && taskColumns && taskTable) {
     toggleBtn.addEventListener('click', (e) => {
       e.preventDefault();
-      taskTable.classList.toggle('hidden');
-      taskColumns.classList.toggle('hidden');
 
-      // Update button text based on current view
-      if (taskColumns.classList.contains('hidden')) {
-        // Showing table view
+      // Toggle visibility using display style
+      if (taskTable.style.display === 'none') {
+        // Currently showing kanban, switch to table
+        taskTable.style.display = '';
+        taskColumns.style.display = 'none';
         toggleBtn.textContent = '📊 Zobrazit Kanban';
       } else {
-        // Showing kanban view
+        // Currently showing table, switch to kanban
+        taskTable.style.display = 'none';
+        taskColumns.style.display = '';
         toggleBtn.textContent = '📋 Zobrazit tabulku';
       }
     });

--- a/fdk_cz/urls.py
+++ b/fdk_cz/urls.py
@@ -30,6 +30,7 @@ from fdk_cz.views.project import create_category, create_document, create_task, 
 from fdk_cz.views.test import  create_test, create_test_error, create_test_result, create_test_type, delete_test_error, detail_test_error, edit_test, edit_test_error,  edit_test_type, list_test_errors, get_test_types, list_tests, list_test_results, list_test_types
 
 from fdk_cz.views.user import login, logout, user_profile, registration, user_settings, toggle_module_visibility
+from fdk_cz.views.help import help_index, help_detail, help_add, help_edit, help_delete
 
 from fdk_cz.views.warehouse import (
     all_stores,
@@ -370,6 +371,13 @@ urlpatterns = (
     path('majetek/kategorie/<int:category_id>/upravit/', edit_asset_category, name='edit_asset_category'),
     path('majetek/kategorie/<int:category_id>/smazat/', delete_asset_category, name='delete_asset_category'),
 
+
+    # Help & Documentation System
+    path('dokumentace/', help_index, name='help_index'),
+    path('dokumentace/pridat/', help_add, name='help_add'),
+    path('dokumentace/<slug:slug>/', help_detail, name='help_detail'),
+    path('dokumentace/<slug:slug>/upravit/', help_edit, name='help_edit'),
+    path('dokumentace/<slug:slug>/smazat/', help_delete, name='help_delete'),
 
     # Articles
     path('clanky/', article_blog_index, name='article_blog_index'),

--- a/fdk_cz/views/help.py
+++ b/fdk_cz/views/help.py
@@ -1,0 +1,174 @@
+# -------------------------------------------------------------------
+#                    VIEWS.HELP.PY
+# -------------------------------------------------------------------
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.shortcuts import render, redirect, get_object_or_404
+from django.utils.text import slugify
+
+from fdk_cz.models import HelpArticle, Module
+
+
+def is_superuser(user):
+    """Check if user is superuser"""
+    return user.is_superuser
+
+
+def help_index(request):
+    """Index page for help/documentation"""
+    user = request.user
+
+    # Get all published articles
+    articles = HelpArticle.objects.filter(is_published=True)
+
+    # Filter technical articles for non-staff users
+    if not (user.is_authenticated and (user.is_superuser or user.is_staff)):
+        articles = articles.filter(is_technical=False)
+
+    # Organize articles by category
+    intro_articles = articles.filter(category='intro').order_by('order', 'title')
+    module_articles = articles.filter(category='module').select_related('module').order_by('order', 'title')
+    technical_articles = articles.filter(category='technical').order_by('order', 'title')
+    faq_articles = articles.filter(category='faq').order_by('order', 'title')
+
+    # Group module articles by module
+    modules_with_articles = {}
+    for article in module_articles:
+        if article.module:
+            if article.module not in modules_with_articles:
+                modules_with_articles[article.module] = []
+            modules_with_articles[article.module].append(article)
+
+    context = {
+        'intro_articles': intro_articles,
+        'modules_with_articles': modules_with_articles,
+        'technical_articles': technical_articles,
+        'faq_articles': faq_articles,
+        'can_edit': user.is_authenticated and user.is_superuser,
+    }
+
+    return render(request, 'help/index.html', context)
+
+
+def help_detail(request, slug):
+    """Detail page for a help article"""
+    user = request.user
+
+    # Get article
+    article = get_object_or_404(HelpArticle, slug=slug, is_published=True)
+
+    # Check if user can view technical articles
+    if article.is_technical and not (user.is_authenticated and (user.is_superuser or user.is_staff)):
+        messages.error(request, "Nemáte oprávnění k zobrazení této technické dokumentace.")
+        return redirect('help_index')
+
+    context = {
+        'article': article,
+        'can_edit': user.is_authenticated and user.is_superuser,
+    }
+
+    return render(request, 'help/detail.html', context)
+
+
+@user_passes_test(is_superuser)
+def help_add(request):
+    """Add a new help article (superuser only)"""
+    if request.method == 'POST':
+        # Create new article
+        article = HelpArticle()
+        article.title = request.POST.get('title')
+        article.slug = slugify(request.POST.get('slug') or request.POST.get('title'))
+        article.content = request.POST.get('content')
+        article.category = request.POST.get('category')
+        article.order = int(request.POST.get('order', 0))
+        article.is_published = request.POST.get('is_published') == 'on'
+        article.is_technical = request.POST.get('is_technical') == 'on'
+        article.meta_description = request.POST.get('meta_description', '')
+        article.keywords = request.POST.get('keywords', '')
+        article.created_by = request.user
+
+        # Module (optional)
+        module_id = request.POST.get('module')
+        if module_id:
+            article.module = Module.objects.get(module_id=module_id)
+
+        article.save()
+
+        messages.success(request, f"Článek '{article.title}' byl úspěšně vytvořen.")
+        return redirect('help_detail', slug=article.slug)
+
+    # GET - show form
+    modules = Module.objects.filter(is_active=True).order_by('display_name')
+
+    context = {
+        'modules': modules,
+        'categories': HelpArticle.CATEGORY_CHOICES,
+    }
+
+    return render(request, 'help/add.html', context)
+
+
+@user_passes_test(is_superuser)
+def help_edit(request, slug):
+    """Edit a help article (superuser only)"""
+    article = get_object_or_404(HelpArticle, slug=slug)
+
+    if request.method == 'POST':
+        # Update article
+        article.title = request.POST.get('title')
+        new_slug = slugify(request.POST.get('slug') or request.POST.get('title'))
+        if new_slug != article.slug:
+            # Check if new slug is unique
+            if HelpArticle.objects.filter(slug=new_slug).exclude(article_id=article.article_id).exists():
+                messages.error(request, "Tento slug již existuje. Zvolte jiný.")
+            else:
+                article.slug = new_slug
+
+        article.content = request.POST.get('content')
+        article.category = request.POST.get('category')
+        article.order = int(request.POST.get('order', 0))
+        article.is_published = request.POST.get('is_published') == 'on'
+        article.is_technical = request.POST.get('is_technical') == 'on'
+        article.meta_description = request.POST.get('meta_description', '')
+        article.keywords = request.POST.get('keywords', '')
+
+        # Module (optional)
+        module_id = request.POST.get('module')
+        if module_id:
+            article.module = Module.objects.get(module_id=module_id)
+        else:
+            article.module = None
+
+        article.save()
+
+        messages.success(request, f"Článek '{article.title}' byl úspěšně upraven.")
+        return redirect('help_detail', slug=article.slug)
+
+    # GET - show form
+    modules = Module.objects.filter(is_active=True).order_by('display_name')
+
+    context = {
+        'article': article,
+        'modules': modules,
+        'categories': HelpArticle.CATEGORY_CHOICES,
+    }
+
+    return render(request, 'help/edit.html', context)
+
+
+@user_passes_test(is_superuser)
+def help_delete(request, slug):
+    """Delete a help article (superuser only)"""
+    article = get_object_or_404(HelpArticle, slug=slug)
+
+    if request.method == 'POST':
+        article_title = article.title
+        article.delete()
+        messages.success(request, f"Článek '{article_title}' byl úspěšně smazán.")
+        return redirect('help_index')
+
+    context = {
+        'article': article,
+    }
+
+    return render(request, 'help/delete.html', context)


### PR DESCRIPTION
Documentation/Help System:
- Added HelpArticle model with categories (intro, module, technical, FAQ)
- Support for module-specific documentation with hierarchical structure
- Technical documentation visible only to admins/testers
- Full CRUD operations (add, edit, delete) for superusers
- Markdown support for article content
- SEO fields (meta_description, keywords)
- URL slug generation
- Views: help_index, help_detail, help_add, help_edit, help_delete
- Templates with responsive design and visual hierarchy
- Added to navigation menu (📚 Dokumentace)

Key Features:
- Organized by categories: General intro, Modules, Technical, FAQ
- Module articles grouped by module with icons
- Published/unpublished control
- Display order customization
- Created/updated timestamps and author tracking
- Empty state handling
- Breadcrumb navigation
- Markdown styling with code blocks, lists, headings

Project Task View Fix:
- Fixed toggle between table and kanban views
- Changed from CSS classes to inline display styles
- Default view is now table (was kanban)
- Button text updates correctly: "Zobrazit Kanban" / "Zobrazit tabulku"
- Resolved display:none conflict with grid layout

Database:
- New table: FDK_help_article
- Foreign key to Module (optional)
- Indexes on category+is_published and module+is_published

URLs: /dokumentace/ with full CRUD endpoints