### PR TITLE
Fix database constraint and grant template issues

### DIFF
--- a/fdk_cz/migrations/0002_alter_projecttask_organization.py
+++ b/fdk_cz/migrations/0002_alter_projecttask_organization.py
@@ -11,6 +11,19 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        # First, drop the old foreign key constraint
+        migrations.RunSQL(
+            sql="""
+                ALTER TABLE FDK_tasks
+                DROP FOREIGN KEY FDK_tasks_organization_id_32c192f0_fk_FDK_company_company_id;
+            """,
+            reverse_sql="""
+                ALTER TABLE FDK_tasks
+                ADD CONSTRAINT FDK_tasks_organization_id_32c192f0_fk_FDK_company_company_id
+                FOREIGN KEY (organization_id) REFERENCES FDK_company(company_id);
+            """
+        ),
+        # Then alter the field to point to Organization
         migrations.AlterField(
             model_name='projecttask',
             name='organization',

--- a/fdk_cz/templates/grants/application_create.html
+++ b/fdk_cz/templates/grants/application_create.html
@@ -238,7 +238,7 @@
       ← Zpět na granty
     </a>
     <span style="color: #6b7280; margin: 0 0.5rem;">/</span>
-    <a href="{% url 'grant_detail' grant.grant_id %}" style="color: #6b7280; text-decoration: none; font-size: 0.875rem;">
+    <a href="{% url 'grant_detail' grant.call_id %}" style="color: #6b7280; text-decoration: none; font-size: 0.875rem;">
       {{ grant.title|truncatewords:5 }}
     </a>
   </nav>
@@ -379,7 +379,7 @@
         <button type="submit" class="btn btn-primary">
           📄 Odeslat žádost
         </button>
-        <a href="{% url 'grant_detail' grant.grant_id %}" class="btn btn-outline">
+        <a href="{% url 'grant_detail' grant.call_id %}" class="btn btn-outline">
           ❌ Zrušit
         </a>
       </div>


### PR DESCRIPTION
- Update migration to drop old FK constraint before creating new one
- This fixes IntegrityError when creating organization tasks
- Fix grant_detail URL in application_create template (call_id vs grant_id)
- Resolves NoReverseMatch error in grants application form

The migration now explicitly drops the old foreign key constraint that references FDK_company before creating the new one to FDK_organization.