### PR TITLE
Add missing IT templates and fix multiply filter

### DIFF
--- a/fdk_cz/templates/it/create_incident.html
+++ b/fdk_cz/templates/it/create_incident.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Nový IT Incident | FDK.cz{% endblock %}
+{% block header_title %}🚨 Nový IT Incident{% endblock %}
+{% block header_subtitle %}Vytvořit nový incident podle ITIL{% endblock %}
+
+{% block content %}
+<div style="max-width: 800px; margin: 0 auto;">
+  <div class="mb-4">
+    <a href="{% url 'list_it_incidents' %}" class="btn btn-outline">← Zpět na seznam</a>
+  </div>
+
+  <div class="content-card">
+    <form method="post">
+      {% csrf_token %}
+
+      <div class="form-group">
+        <label for="{{ form.title.id_for_label }}" class="form-label">Název incidentu <span class="required">*</span></label>
+        {{ form.title }}
+        {% if form.title.errors %}
+          <div class="error-message">{{ form.title.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.incident_number.id_for_label }}" class="form-label">Číslo incidentu <span class="required">*</span></label>
+        {{ form.incident_number }}
+        <div class="form-help">Např. INC-001</div>
+        {% if form.incident_number.errors %}
+          <div class="error-message">{{ form.incident_number.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.description.id_for_label }}" class="form-label">Popis incidentu <span class="required">*</span></label>
+        {{ form.description }}
+        {% if form.description.errors %}
+          <div class="error-message">{{ form.description.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label for="{{ form.organization.id_for_label }}" class="form-label">Organizace <span class="required">*</span></label>
+          {{ form.organization }}
+          {% if form.organization.errors %}
+            <div class="error-message">{{ form.organization.errors }}</div>
+          {% endif %}
+        </div>
+
+        <div class="form-group">
+          <label for="{{ form.priority.id_for_label }}" class="form-label">Priorita <span class="required">*</span></label>
+          {{ form.priority }}
+          {% if form.priority.errors %}
+            <div class="error-message">{{ form.priority.errors }}</div>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="form-row">
+        <div class="form-group">
+          <label for="{{ form.status.id_for_label }}" class="form-label">Status <span class="required">*</span></label>
+          {{ form.status }}
+          {% if form.status.errors %}
+            <div class="error-message">{{ form.status.errors }}</div>
+          {% endif %}
+        </div>
+
+        <div class="form-group">
+          <label for="{{ form.assigned_to.id_for_label }}" class="form-label">Přiřazeno</label>
+          {{ form.assigned_to }}
+          {% if form.assigned_to.errors %}
+            <div class="error-message">{{ form.assigned_to.errors }}</div>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.affected_asset.id_for_label }}" class="form-label">Postižené aktivum</label>
+        {{ form.affected_asset }}
+        {% if form.affected_asset.errors %}
+          <div class="error-message">{{ form.affected_asset.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-group">
+        <label for="{{ form.resolution_notes.id_for_label }}" class="form-label">Poznámky k řešení</label>
+        {{ form.resolution_notes }}
+        {% if form.resolution_notes.errors %}
+          <div class="error-message">{{ form.resolution_notes.errors }}</div>
+        {% endif %}
+      </div>
+
+      <div class="form-actions">
+        <button type="submit" class="btn btn-primary">💾 Vytvořit incident</button>
+        <a href="{% url 'list_it_incidents' %}" class="btn btn-outline">Zrušit</a>
+      </div>
+    </form>
+  </div>
+</div>
+{% endblock %}

--- a/fdk_cz/templates/it/list_incidents.html
+++ b/fdk_cz/templates/it/list_incidents.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+{% block title %}IT Incidenty | FDK.cz{% endblock %}
+{% block header_title %}🚨 IT Incidenty{% endblock %}
+{% block header_subtitle %}Přehled IT incidentů podle ITIL{% endblock %}
+
+{% block content %}
+<div style="max-width: 1400px; margin: 0 auto;">
+  <!-- Actions -->
+  <div class="mb-10 flex gap-3">
+    <a href="{% url 'create_it_incident' %}" class="btn btn-primary">+ Nový incident</a>
+    <a href="{% url 'it_dashboard' %}" class="btn btn-outline">Dashboard</a>
+    <a href="{% url 'list_it_assets' %}" class="btn btn-outline">IT Aktiva</a>
+  </div>
+
+  <div class="content-card">
+    {% if incidents %}
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Číslo</th>
+            <th>Název</th>
+            <th>Organizace</th>
+            <th>Priorita</th>
+            <th>Status</th>
+            <th>Nahlášeno</th>
+            <th style="text-align: center;">Akce</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for incident in incidents %}
+          <tr>
+            <td><strong>{{ incident.incident_number }}</strong></td>
+            <td>{{ incident.title }}</td>
+            <td>{{ incident.organization.name|default:"—" }}</td>
+            <td>
+              <span class="badge {% if incident.priority == 'critical' %}badge-danger{% elif incident.priority == 'high' %}badge-warning{% else %}badge-info{% endif %}">
+                {{ incident.get_priority_display|default:incident.priority }}
+              </span>
+            </td>
+            <td>
+              <span class="badge {% if incident.status == 'resolved' %}badge-success{% elif incident.status == 'in_progress' %}badge-warning{% else %}badge-secondary{% endif %}">
+                {{ incident.get_status_display|default:incident.status }}
+              </span>
+            </td>
+            <td>{{ incident.created_at|date:"d.m.Y H:i"|default:"—" }}</td>
+            <td style="text-align: center;">
+              <a href="{% url 'detail_it_incident' incident.incident_id %}" class="btn btn-sm btn-outline">Detail</a>
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <div style="text-align: center; padding: 3rem;">
+        <div style="font-size: 4rem; margin-bottom: 1rem;">🚨</div>
+        <p style="color: #64748b;">Zatím nejsou žádné IT incidenty k zobrazení.</p>
+        <a href="{% url 'create_it_incident' %}" class="btn btn-primary mt-4">+ Vytvořit první incident</a>
+      </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/fdk_cz/templates/risk/risk_matrix.html
+++ b/fdk_cz/templates/risk/risk_matrix.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load functions %}
 {% block title %}Matice rizik | FDK.cz{% endblock %}
 {% block header_title %}📊 Matice rizik{% endblock %}
 {% block header_subtitle %}Vizualizace rizik podle pravděpodobnosti a dopadu{% endblock %}

--- a/fdk_cz/templatetags/functions.py
+++ b/fdk_cz/templatetags/functions.py
@@ -7,6 +7,17 @@ import re
 register = template.Library()
 
 @register.filter
+def multiply(value, arg):
+    """
+    Multiplies the value by the argument.
+    Usage: {{ value|multiply:2 }}
+    """
+    try:
+        return int(value) * int(arg)
+    except (ValueError, TypeError):
+        return 0
+
+@register.filter
 def replace_url_with_link(value):
     # Regulární výraz pro URL https://fdk.cz
     url_pattern = r"https://fdk\.cz"


### PR DESCRIPTION
1. Create IT incident templates:
   - Add create_incident.html for creating new IT incidents
   - Add list_incidents.html for listing all incidents
   - Both templates follow existing IT module design patterns

2. Fix multiply filter in risk matrix:
   - Add multiply custom template filter to templatetags/functions.py
   - Load functions templatetag in risk_matrix.html
   - Create __init__.py in templatetags to make it a Python package
   - Fixes TemplateSyntaxError when calculating risk scores

These changes enable full IT incident management functionality and fix the risk matrix visualization that was broken due to missing filter.