### PR TITLE
Remove tips sections and improve dashboard styling

### DIFF
--- a/fdk_cz/templates/accounting/accounting_dashboard.html
+++ b/fdk_cz/templates/accounting/accounting_dashboard.html
@@ -82,21 +82,5 @@
     </div>
     {% endif %}
   </div>
-
-  <!-- Help Card -->
-  <div class="content-card mt-6 bg-gradient-to-br from-blue-50 to-indigo-50 border-2 border-blue-200">
-    <div class="flex items-start">
-      <div class="text-3xl mr-4">💡</div>
-      <div>
-        <h4 class="font-semibold text-gray-800 mb-2">Tipy pro správu účetnictví</h4>
-        <ul class="text-sm text-gray-700 space-y-1">
-          <li>• Pravidelně kontrolujte stav faktur a termíny splatnosti</li>
-          <li>• Udržujte aktuální informace o zákaznících a dodavatelích</li>
-          <li>• Využívejte automatické upomínky pro nezaplacené faktury</li>
-          <li>• Zálohujte si důležitá účetní data</li>
-        </ul>
-      </div>
-    </div>
-  </div>
 </div>
 {% endblock %}

--- a/fdk_cz/templates/asset/dashboard.html
+++ b/fdk_cz/templates/asset/dashboard.html
@@ -169,21 +169,5 @@
       {% endif %}
     </div>
   </div>
-
-  <!-- Quick Info -->
-  <div class="content-card mt-6 bg-gradient-to-br from-blue-50 to-indigo-50 border-2 border-blue-200">
-    <div class="flex items-start">
-      <div class="text-3xl mr-4">💡</div>
-      <div>
-        <h4 class="font-semibold text-gray-800 mb-2">Tipy pro správu majetku</h4>
-        <ul class="text-sm text-gray-700 space-y-1">
-          <li>• Pravidelně kontrolujte stav majetku a aktualizujte jeho hodnotu</li>
-          <li>• Přiřazujte zodpovědné osoby k jednotlivým položkám</li>
-          <li>• Využívejte kategorie pro lepší organizaci</li>
-          <li>• Sledujte záruční lhůty a termíny údržby</li>
-        </ul>
-      </div>
-    </div>
-  </div>
 </div>
 {% endblock %}

--- a/fdk_cz/templates/contact/create_contact.html
+++ b/fdk_cz/templates/contact/create_contact.html
@@ -4,12 +4,9 @@
 {% block title %}{% trans "Nový kontakt" %}{% endblock %}
 
 {% block content %}
-<div class="container mx-auto mt-5 px-4 max-w-screen-lg">
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        
-        <!-- Levý blok 2/3 - Formulář pro vytvoření kontaktu -->
-        <div class="col-span-2 bg-white p-6 rounded-lg shadow-md">
-            <h2 class="text-2xl font-semibold text-gray-700 mb-4">{% trans "Nový kontakt" %}</h2>
+<div class="container mx-auto mt-5 px-4" style="max-width: 900px;">
+    <div class="content-card">
+        <h2 class="text-2xl font-semibold text-gray-700 mb-4">{% trans "Nový kontakt" %}</h2>
             <form method="POST">
                 {% csrf_token %}
 
@@ -87,13 +84,6 @@
                     </button>
                 </div>
             </form>
-        </div>
-
-        <!-- Pravý blok 1/3 - Informace o kontaktech -->
-        <div class="bg-gray-50 p-6 rounded-lg shadow-md flex flex-col items-center justify-center">
-            <h1 class="text-2xl font-bold text-gray-700 mb-2">FDK.cz</h1>
-            <p class="text-lg font-semibold text-gray-600">{% trans "Správa kontaktů" %}</p>
-        </div>
     </div>
 </div>
 {% endblock %}

--- a/fdk_cz/templates/contact/edit_contact.html
+++ b/fdk_cz/templates/contact/edit_contact.html
@@ -4,10 +4,8 @@
 {% block title %}Editace kontaktu{% endblock %}
 
 {% block content %}
-<div class="container mx-auto mt-5 px-4 max-w-screen-lg grid grid-cols-1 lg:grid-cols-3 gap-6">
-
-    <!-- Levý blok 2/3 - Formulář pro editaci kontaktu -->
-    <div class="col-span-2 bg-white p-6 rounded-lg shadow-md">
+<div class="container mx-auto mt-5 px-4" style="max-width: 900px;">
+    <div class="content-card">
         <h1 class="text-2xl font-semibold text-gray-700 mb-4">{% trans "Editace kontaktu" %}</h1>
         
         <form method="POST" class="space-y-4">
@@ -88,20 +86,5 @@
             </button>
         </form>
     </div>
-
-    <!-- Pravý blok 1/3 - Pomocník s informacemi -->
-    <div class="bg-gray-50 p-6 rounded-lg shadow-md text-center">
-        <h2 class="text-lg font-semibold text-gray-700 mb-4">{% trans "Pomocník" %}</h2>
-        <p class="text-gray-600 mb-4">
-            {% trans "Tento formulář umožňuje upravit údaje kontaktu, jako jsou jméno, email a další informace." %}
-        </p>
-        <p class="text-gray-600">{% trans "Přidejte kontakt k projektu nebo označte jako soukromý podle potřeby." %}</p>
-
-        <!-- FDK.cz v šedé barvě -->
-        <div class="mt-8 text-center bg-gray-200 py-3 rounded">
-            <p class="font-semibold text-gray-700"><a href="https://fdk.cz">FDK.cz</a></p>
-        </div>
-    </div>
-
 </div>
 {% endblock %}

--- a/fdk_cz/templates/contact/list_contacts.html
+++ b/fdk_cz/templates/contact/list_contacts.html
@@ -134,21 +134,5 @@
       </div>
     {% endif %}
   </div>
-
-  <!-- Info Card -->
-  <div class="content-card mt-6 bg-gradient-to-br from-blue-50 to-indigo-50 border-2 border-blue-200">
-    <div class="flex items-start">
-      <div class="text-3xl mr-4">💡</div>
-      <div>
-        <h4 class="font-semibold text-gray-800 mb-2">Tipy pro správu kontaktů</h4>
-        <ul class="text-sm text-gray-700 space-y-1">
-          <li>• Přiřazujte kontakty k projektům pro lepší organizaci</li>
-          <li>• Udržujte aktuální kontaktní údaje a pozice</li>
-          <li>• Využívejte poznámky pro zaznamenání důležitých informací</li>
-          <li>• Filtrujte kontakty podle projektů pro rychlé vyhledávání</li>
-        </ul>
-      </div>
-    </div>
-  </div>
 </div>
 {% endblock %}

--- a/fdk_cz/templatetags/functions.py
+++ b/fdk_cz/templatetags/functions.py
@@ -18,6 +18,16 @@ def multiply(value, arg):
         return 0
 
 @register.filter
+def dict_lookup(dictionary, key):
+    """
+    Looks up a key in a dictionary.
+    Usage: {{ my_dict|dict_lookup:"key_name" }}
+    """
+    if isinstance(dictionary, dict):
+        return dictionary.get(key, [])
+    return []
+
+@register.filter
 def replace_url_with_link(value):
     # Regulární výraz pro URL https://fdk.cz
     url_pattern = r"https://fdk\.cz"


### PR DESCRIPTION
1. Add dict_lookup filter to templatetags:
   - Enables dictionary lookup in templates
   - Used in risk_matrix for matrix_data lookups
   - Fixes TemplateSyntaxError

2. Clean up contacts module:
   - Remove tips card from list_contacts.html
   - Remove helper sidebar from create_contact.html
   - Remove helper sidebar from edit_contact.html
   - Make forms full-width and cleaner
   - Use consistent content-card styling

3. Remove tips sections from dashboards:
   - Remove tips from accounting dashboard
   - Remove tips from asset management dashboard
   - Cleaner, more focused UI without outdated design elements

These changes modernize the UI by removing legacy design elements and provide cleaner, more focused user interface across all modules.