### PR TITLE
Fix action button margins and remove testing tips

### DIFF
--- a/fdk_cz/templates/accounting/accounting_dashboard.html
+++ b/fdk_cz/templates/accounting/accounting_dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10 flex gap-3">
+  <div class="mb-6 flex gap-3">
     <a href="{% url 'create_invoice' %}" class="btn btn-primary">+ Nová faktura</a>
     <a href="{% url 'list_invoices' %}" class="btn btn-outline">Všechny faktury</a>
     <a href="{% url 'free_invoice' %}" class="btn btn-outline">Vytvoř fakturu zdarma</a>

--- a/fdk_cz/templates/asset/dashboard.html
+++ b/fdk_cz/templates/asset/dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10 flex gap-3">
+  <div class="mb-6 flex gap-3">
     <a href="{% url 'create_asset' %}" class="btn btn-primary">+ Nový majetek</a>
     <a href="{% url 'list_assets' %}" class="btn btn-secondary">📋 Všechen majetek</a>
     <a href="{% url 'list_asset_categories' %}" class="btn btn-outline">🏷️ Kategorie</a>

--- a/fdk_cz/templates/b2b/dashboard.html
+++ b/fdk_cz/templates/b2b/dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10">
+  <div class="mb-6">
     <a href="{% url 'create_b2b_company' %}" class="btn btn-primary">+ Nová firma</a>
     <a href="{% url 'create_b2b_contract' %}" class="btn btn-secondary ml-2">+ Nová smlouva</a>
     <a href="{% url 'list_b2b_companies' %}" class="btn btn-outline ml-2">Všechny firmy</a>

--- a/fdk_cz/templates/hr/dashboard.html
+++ b/fdk_cz/templates/hr/dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10 flex gap-3">
+  <div class="mb-6 flex gap-3">
     <a href="{% url 'create_employee' %}" class="btn btn-primary">+ Nový zaměstnanec</a>
     <a href="{% url 'create_department' %}" class="btn btn-secondary">+ Nové oddělení</a>
     <a href="{% url 'list_employees' %}" class="btn btn-outline">Všichni zaměstnanci</a>

--- a/fdk_cz/templates/it/dashboard.html
+++ b/fdk_cz/templates/it/dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10 flex gap-3">
+  <div class="mb-6 flex gap-3">
     <a href="{% url 'create_it_asset' %}" class="btn btn-primary">+ Nové aktivum</a>
     <a href="{% url 'create_it_incident' %}" class="btn btn-secondary">+ Nový incident</a>
     <a href="{% url 'list_it_assets' %}" class="btn btn-outline">Všechna aktiva</a>

--- a/fdk_cz/templates/risk/dashboard.html
+++ b/fdk_cz/templates/risk/dashboard.html
@@ -6,7 +6,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10 flex gap-3">
+  <div class="mb-6 flex gap-3">
     <a href="{% url 'create_risk' %}" class="btn btn-primary">+ Nové riziko</a>
     <a href="{% url 'list_risks' %}" class="btn btn-outline">Všechna rizika</a>
     <a href="{% url 'risk_matrix' %}" class="btn btn-outline">Riziková matice</a>

--- a/fdk_cz/templates/test/list_tests.html
+++ b/fdk_cz/templates/test/list_tests.html
@@ -8,7 +8,7 @@
 {% block content %}
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
-  <div class="mb-10 flex gap-3">
+  <div class="mb-6 flex gap-3">
     <a href="{% url 'create_test' %}" class="btn btn-primary">+ {% trans "Nový test" %}</a>
     <a href="{% url 'create_test_type' %}" class="btn btn-outline">+ {% trans "Nový typ testu" %}</a>
     <a href="{% url 'create_test_error' %}" class="btn btn-outline">+ {% trans "Nová chyba" %}</a>
@@ -128,22 +128,6 @@
       <a href="{% url 'create_test_error' %}" class="btn btn-outline btn-sm">+ {% trans "Přidat chybu" %}</a>
     </div>
     {% endif %}
-  </div>
-
-  <!-- Help Card -->
-  <div class="content-card mt-6 bg-gradient-to-br from-blue-50 to-indigo-50 border-2 border-blue-200">
-    <div class="flex items-start">
-      <div class="text-3xl mr-4">💡</div>
-      <div>
-        <h4 class="font-semibold text-gray-800 mb-2">{% trans "Tipy pro správu testování" %}</h4>
-        <ul class="text-sm text-gray-700 space-y-1">
-          <li>• {% trans "Pravidelně vytvářejte a aktualizujte testy pro kritické části aplikace" %}</li>
-          <li>• {% trans "Kategorizujte testy podle typů pro lepší organizaci" %}</li>
-          <li>• {% trans "Sledujte a rychle řešte nahlášené chyby" %}</li>
-          <li>• {% trans "Dokumentujte očekávané výsledky testů" %}</li>
-        </ul>
-      </div>
-    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
1. Remove tips section from testing module:
   - Remove help card from list_tests.html
   - Cleaner UI without legacy design elements

2. Fix action button margins across all dashboards:
   - Change mb-10 to mb-6 for better spacing
   - Prevents buttons from being glued to content below
   - Applies to: accounting, asset, B2B, HR, IT, risk, testing

These changes provide consistent spacing across all module dashboards and remove outdated design elements for a cleaner, more modern UI.