### PR TITLE
Fix module visibility and breadcrumb navigation

### DIFF
--- a/fdk_cz/templates/base.html
+++ b/fdk_cz/templates/base.html
@@ -181,8 +181,7 @@
 
             <nav class="breadcrumb">
               <a href="{% url 'index' %}" class="breadcrumb-item">Domů</a>
-              <span class="breadcrumb-separator">/</span>
-              <span class="breadcrumb-item active">{% block breadcrumb %}Dashboard{% endblock %}</span>
+              {% block breadcrumb %}{% endblock %}
             </nav>
           </div>
 

--- a/fdk_cz/templates/index.html
+++ b/fdk_cz/templates/index.html
@@ -28,7 +28,7 @@
   {% endif %}
 {% endblock %}
 
-{% block breadcrumb %}Dashboard{% endblock %}
+{% block breadcrumb %}{% endblock %}
 
 {% block content %}
 <!-- AI Právo výstupy -->

--- a/fdk_cz/views/user.py
+++ b/fdk_cz/views/user.py
@@ -63,11 +63,14 @@ def user_settings(request):
 
     # Prepare modules with their preference status
     modules_with_prefs = []
+    default_visible_modules = ['project_management', 'task_management']
     for module in modules:
         pref = user_preferences.get(module.module_id)
+        # Default: only project_management and task_management are visible
+        default_visible = module.name in default_visible_modules
         modules_with_prefs.append({
             'module': module,
-            'is_visible': pref.is_visible if pref else True,  # Default to visible
+            'is_visible': pref.is_visible if pref else default_visible,
             'preference': pref
         })
 


### PR DESCRIPTION
Changes:
- Fixed user_settings view to show correct default module visibility
  * Only project_management and task_management are visible by default
  * Other modules are hidden until explicitly enabled
  * This matches the logic in context_processors.py

- Simplified breadcrumb navigation in base.html
  * Removed hardcoded "Dashboard" from breadcrumb
  * Now shows just "Domů" on index page
  * Individual pages can override breadcrumb block if needed

- Fixed index.html breadcrumb to be empty

Note: To populate modules in database, run:
  python manage.py init_modules