### PR TITLE
Fix debugging and remove real company names from landing pages

### DIFF
--- a/fdk_cz/context_processors.py
+++ b/fdk_cz/context_processors.py
@@ -1,9 +1,6 @@
 # fdk_cz/context_processors.py
 
 from fdk_cz.models import UserModuleSubscription, Module, UserModulePreference
-import logging
-
-logger = logging.getLogger(__name__)
 
 
 def user_modules(request):
@@ -17,9 +14,9 @@ def user_modules(request):
             'visible_modules': []
         }
 
-    # DEBUG: Log module count
+    # DEBUG: Print to stdout (visible in nohup.out)
     module_count = Module.objects.count()
-    logger.warning(f"DEBUG: Total modules in DB: {module_count}")
+    print(f"🔍 DEBUG context_processors: Total modules in DB: {module_count}")
 
     # Získat všechny aktivní moduly uživatele
     subscriptions = UserModuleSubscription.objects.filter(
@@ -40,37 +37,58 @@ def user_modules(request):
         'contacts': True
     })
 
+    print(f"🔍 DEBUG: user_has_module = {user_has_module}")
+
     # Všechny moduly
     all_modules = Module.objects.filter(is_active=True).order_by('order')
-    logger.warning(f"DEBUG: Active modules: {all_modules.count()}")
+    print(f"🔍 DEBUG: Active modules count: {all_modules.count()}")
+
+    # Print all module names
+    for m in all_modules:
+        print(f"   - Module: {m.name} (id={m.module_id}, display={m.display_name})")
 
     # Získat preferences uživatele
     user_prefs = {}
     for pref in UserModulePreference.objects.filter(user=request.user).select_related('module'):
         user_prefs[pref.module.module_id] = pref
+        print(f"🔍 DEBUG: User pref for {pref.module.name}: visible={pref.is_visible}")
 
     # Moduly viditelné v menu (respektuje UserModulePreference)
     visible_modules = []
     for module in all_modules:
+        print(f"🔍 DEBUG: Checking module {module.name}...")
+
         # Kontrola jestli má uživatel přístup k modulu
-        if user_has_module.get(module.name, False):
+        has_access = user_has_module.get(module.name, False)
+        print(f"   - Has access: {has_access}")
+
+        if has_access:
             # Kontrola jestli má uživatel preference pro tento modul
             pref = user_prefs.get(module.module_id)
+            print(f"   - Preference: {pref}")
 
             # Defaultně viditelné jsou jen project_management a task_management
             if pref:
                 # Uživatel má nastavenou preferenci
                 if pref.is_visible:
                     visible_modules.append(module)
-                    logger.warning(f"DEBUG: Module {module.name} visible (user pref)")
+                    print(f"   ✅ Module {module.name} VISIBLE (user pref)")
+                else:
+                    print(f"   ❌ Module {module.name} HIDDEN (user pref)")
             else:
                 # Žádná preference - použij default
                 # Pouze projekty a úkoly jsou defaultně viditelné
                 if module.name in ['project_management', 'task_management']:
                     visible_modules.append(module)
-                    logger.warning(f"DEBUG: Module {module.name} visible (default)")
+                    print(f"   ✅ Module {module.name} VISIBLE (default)")
+                else:
+                    print(f"   ⚪ Module {module.name} HIDDEN (default, no pref)")
+        else:
+            print(f"   ❌ Module {module.name} - NO ACCESS")
 
-    logger.warning(f"DEBUG: Total visible modules: {len(visible_modules)}")
+    print(f"🔍 DEBUG: Total visible modules: {len(visible_modules)}")
+    for m in visible_modules:
+        print(f"   ✅ {m.name}")
 
     return {
         'user_has_module': user_has_module,

--- a/fdk_cz/templates/modules/grants_landing.html
+++ b/fdk_cz/templates/modules/grants_landing.html
@@ -158,7 +158,7 @@
         <p style="color: #64748b; margin-bottom: 1rem;">
           Technologická firma získala grant z Horizont Evropa na vývoj AI řešení
         </p>
-        <div style="font-weight: 600; color: #1e293b;">— TechStart s.r.o.</div>
+        <div style="font-weight: 600; color: #1e293b;">— Technologická firma z ČR</div>
       </div>
 
       <div class="content-card" style="border-left: 4px solid #3b82f6;">
@@ -166,15 +166,15 @@
         <p style="color: #64748b; margin-bottom: 1rem;">
           Nezisková organizace získala ESF dotaci na vzdělávací program
         </p>
-        <div style="font-weight: 600; color: #1e293b;">— Vzdělávání+ z.s.</div>
+        <div style="font-weight: 600; color: #1e293b;">— Vzdělávací neziskovka</div>
       </div>
 
       <div class="content-card" style="border-left: 4px solid #f59e0b;">
         <div style="color: #f59e0b; font-size: 2rem; font-weight: 700; margin-bottom: 0.5rem;">€85,000</div>
         <p style="color: #64748b; margin-bottom: 1rem;">
-          Malá firma získala podporu z OP TAK na inovace výroby
+          Výrobní firma získala podporu z OP TAK na inovace výroby
         </p>
-        <div style="font-weight: 600; color: #1e293b;">— ProduceIt s.r.o.</div>
+        <div style="font-weight: 600; color: #1e293b;">— Malá výrobní firma</div>
       </div>
     </div>
   </div>

--- a/fdk_cz/templates/modules/project_management_landing.html
+++ b/fdk_cz/templates/modules/project_management_landing.html
@@ -90,8 +90,8 @@
     <h2 style="font-size: 1.75rem; font-weight: 700; margin-bottom: 1rem; color: #1e293b; text-align: center;">
       📸 Podívejte se na FDK v akci
     </h2>
-    <div style="background: #e2e8f0; border-radius: 8px; height: 400px; display: flex; align-items: center; justify-content: center; color: #64748b; font-size: 1.5rem;">
-      [ Zde bude screenshot / demo video ]
+    <div style="border-radius: 8px; overflow: hidden; box-shadow: 0 10px 30px rgba(0,0,0,0.2);">
+      <img src="/static/img/screenshots/fdk.webp" alt="FDK.cz - Správa projektů" style="width: 100%; height: auto; display: block;">
     </div>
     <p style="text-align: center; color: #64748b; margin-top: 1rem;">
       Intuitivní rozhraní navržené pro maximální produktivitu
@@ -130,7 +130,7 @@
         <p style="font-style: italic; color: #64748b; margin-bottom: 1rem;">
           "FDK nám pomohl snížit čas na projekt planning o 60%. Neuvěřitelně intuitivní!"
         </p>
-        <div style="font-weight: 600; color: #1e293b;">— Jana K., Project Manager</div>
+        <div style="font-weight: 600; color: #1e293b;">— Jana K., Projektová manažerka</div>
       </div>
 
       <div class="content-card">
@@ -138,7 +138,7 @@
         <p style="font-style: italic; color: #64748b; margin-bottom: 1rem;">
           "Konečně projektový nástroj který opravdu funguje. A ještě je to zdarma!"
         </p>
-        <div style="font-weight: 600; color: #1e293b;">— Petr M., CEO StartupHub</div>
+        <div style="font-weight: 600; color: #1e293b;">— Petr M., CEO technologické firmy</div>
       </div>
 
       <div class="content-card">
@@ -146,7 +146,7 @@
         <p style="font-style: italic; color: #64748b; margin-bottom: 1rem;">
           "Skvělá podpora českého jazyka a místních standardů. Doporučuji!"
         </p>
-        <div style="font-weight: 600; color: #1e293b;">— Martin S., IT Lead</div>
+        <div style="font-weight: 600; color: #1e293b;">— Martin S., IT vedoucí</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
1. Changed logging to print() for visibility in nohup.out
   - logger.warning() wasn't showing in stdout
   - Added extensive debug output with emojis for easy filtering
   - Shows all modules, access checks, and visibility decisions

2. Removed real company names from testimonials
   - "TechStart s.r.o." → "Technologická firma z ČR"
   - "Vzdělávání+ z.s." → "Vzdělávací neziskovka"
   - "ProduceIt s.r.o." → "Malá výrobní firma"
   - "StartupHub" → "CEO technologické firmy"
   - Generic job titles instead of company names

3. Added real screenshot to project management landing
   - Replaced placeholder with /static/img/screenshots/fdk.webp
   - Added shadow and proper styling

After restart service, check logs with:
  tail -f nohup.out | grep "🔍 DEBUG"

This will show exactly why modules aren't appearing in menu.