### PR TITLE
Simplify navigation: move org switcher to sidebar, remove breadcrumbs

### DIFF
--- a/fdk_cz/templates/asset/dashboard.html
+++ b/fdk_cz/templates/asset/dashboard.html
@@ -4,22 +4,6 @@
 {% block header_subtitle %}Správa majetku a skladu organizace{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Sklad a majetek</span>
-  </div>
-</div>
-
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
   <div class="content-card mb-6">

--- a/fdk_cz/templates/b2b/dashboard.html
+++ b/fdk_cz/templates/b2b/dashboard.html
@@ -4,22 +4,6 @@
 {% block header_subtitle %}Správa B2B vztahů a obchodních smluv{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">B2B Management</span>
-  </div>
-</div>
-
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
   <div class="content-card mb-6">

--- a/fdk_cz/templates/base.html
+++ b/fdk_cz/templates/base.html
@@ -50,41 +50,41 @@
           <a href="{% url 'index' %}" class="nav-item {% if request.resolver_match.url_name == 'index' %}active{% endif %}">
             <span class="nav-icon">&#127968;</span> Domů
           </a>
-        </div>
-
-        {% if user.is_authenticated and user_organizations %}
-        <!-- Organization Context Switcher -->
-        <div class="nav-section">
-          <div class="nav-section-title">Kontext</div>
-          <div style="padding: 0.5rem 1rem; margin-bottom: 0.5rem;">
-            <!-- Current context display -->
-            <div style="background: {% if current_organization %}linear-gradient(to right, #dbeafe, #e0e7ff){% else %}linear-gradient(to right, #fef3c7, #fde68a){% endif %}; border-radius: 8px; padding: 0.75rem; margin-bottom: 0.75rem;">
-              <div style="font-size: 0.75rem; color: #64748b; margin-bottom: 0.25rem;">Aktuální kontext:</div>
-              <div style="font-weight: 600; color: #1e293b; display: flex; align-items: center; gap: 0.5rem;">
+          {% if user.is_authenticated and user_organizations %}
+          <!-- Organization Switcher under Hlavní -->
+          <div class="nav-item-expandable">
+            <div class="nav-item" onclick="toggleOrgSwitcher()" style="cursor: pointer; display: flex; justify-content: space-between; align-items: center;">
+              <span><span class="nav-icon">&#127970;</span> Organizace</span>
+              <span id="orgExpandIcon" style="font-size: 0.75rem; transition: transform 0.2s;">&#9660;</span>
+            </div>
+            <div id="orgSwitcherPanel" style="display: none; padding: 0.5rem 0.5rem 0.5rem 2rem; background: #f8fafc; border-radius: 0 0 8px 8px;">
+              <!-- Current context -->
+              <div style="font-size: 0.75rem; color: #64748b; margin-bottom: 0.5rem;">Aktuální:</div>
+              <div style="background: {% if current_organization %}#dbeafe{% else %}#fef3c7{% endif %}; border-radius: 6px; padding: 0.5rem; margin-bottom: 0.75rem; font-weight: 600; font-size: 0.875rem; color: #1e293b;">
                 {% if current_organization %}
-                  <span>&#127970;</span> {{ current_organization.name }}
+                  &#127970; {{ current_organization.name }}
                 {% else %}
-                  <span>&#128100;</span> Osobní
+                  &#128100; Osobní
                 {% endif %}
               </div>
-            </div>
-            <!-- Context switcher dropdown -->
-            <div style="font-size: 0.75rem; color: #64748b; margin-bottom: 0.5rem;">Přepnout na:</div>
-            {% if not is_personal_context %}
-            <a href="{% url 'set_personal_context' %}" style="display: block; padding: 0.5rem; background: #f8fafc; border-radius: 4px; margin-bottom: 0.25rem; color: #475569; text-decoration: none; font-size: 0.875rem; transition: background 0.2s;">
-              <span>&#128100;</span> Osobní
-            </a>
-            {% endif %}
-            {% for org in user_organizations %}
-              {% if org != current_organization %}
-              <a href="{% url 'set_organization_context' org.organization_id %}" style="display: block; padding: 0.5rem; background: #f8fafc; border-radius: 4px; margin-bottom: 0.25rem; color: #475569; text-decoration: none; font-size: 0.875rem; transition: background 0.2s;">
-                <span>&#127970;</span> {{ org.name }}
+              <!-- Switcher options -->
+              <div style="font-size: 0.75rem; color: #64748b; margin-bottom: 0.5rem;">Přepnout na:</div>
+              {% if not is_personal_context %}
+              <a href="{% url 'set_personal_context' %}" style="display: block; padding: 0.4rem 0.5rem; background: white; border-radius: 4px; margin-bottom: 0.25rem; color: #475569; text-decoration: none; font-size: 0.8rem; border: 1px solid #e2e8f0;">
+                &#128100; Osobní
               </a>
               {% endif %}
-            {% endfor %}
+              {% for org in user_organizations %}
+                {% if org != current_organization %}
+                <a href="{% url 'set_organization_context' org.organization_id %}" style="display: block; padding: 0.4rem 0.5rem; background: white; border-radius: 4px; margin-bottom: 0.25rem; color: #475569; text-decoration: none; font-size: 0.8rem; border: 1px solid #e2e8f0;">
+                  &#127970; {{ org.name }}
+                </a>
+                {% endif %}
+              {% endfor %}
+            </div>
           </div>
+          {% endif %}
         </div>
-        {% endif %}
 
         {% if not user.is_authenticated %}
         <!-- Menu pro nepřihlášené uživatele - vábnička -->
@@ -407,6 +407,17 @@
     }
     function toggleUserMenu() {
       document.getElementById('userDropdownMenu').classList.toggle('active');
+    }
+    function toggleOrgSwitcher() {
+      const panel = document.getElementById('orgSwitcherPanel');
+      const icon = document.getElementById('orgExpandIcon');
+      if (panel.style.display === 'none') {
+        panel.style.display = 'block';
+        icon.style.transform = 'rotate(180deg)';
+      } else {
+        panel.style.display = 'none';
+        icon.style.transform = 'rotate(0deg)';
+      }
     }
     document.addEventListener('click', e => {
       const userMenu = document.getElementById('userDropdownMenu');

--- a/fdk_cz/templates/contact/list_contacts.html
+++ b/fdk_cz/templates/contact/list_contacts.html
@@ -5,22 +5,6 @@
 {% block header_subtitle %}Správa kontaktů a obchodních partnerů{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Kontakty</span>
-  </div>
-</div>
-
 <div class="max-w-7xl mx-auto">
   <!-- Contacts Grid -->
   <div class="content-card">

--- a/fdk_cz/templates/contract/list_contract.html
+++ b/fdk_cz/templates/contract/list_contract.html
@@ -6,22 +6,6 @@
 {% block header_subtitle %}Správa všech smluv v systému{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Seznam smluv</span>
-  </div>
-</div>
-
 <div style="max-width: 1200px; margin: 0 auto;">
 
   <!-- Actions -->

--- a/fdk_cz/templates/dms/dashboard.html
+++ b/fdk_cz/templates/dms/dashboard.html
@@ -4,22 +4,6 @@
 {% block header_subtitle %}Centralizovaný systém pro správu všech dokumentů{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">DMS - Správa dokumentů</span>
-  </div>
-</div>
-
 <div class="max-w-7xl mx-auto">
 
   {% if is_demo %}

--- a/fdk_cz/templates/grants/grant_list.html
+++ b/fdk_cz/templates/grants/grant_list.html
@@ -15,22 +15,6 @@
 {% block content %}
 <div style="max-width: 1400px; margin: 0 auto;">
 
-  <!-- Breadcrumbs -->
-  <div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-    <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-      <span style="color: #64748b;">📍 Kontext:</span>
-      {% if current_organization %}
-        <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-          {{ current_organization.name }}
-        </a>
-      {% else %}
-        <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-      {% endif %}
-      <span style="color: #9ca3af;">→</span>
-      <span style="font-weight: 600; color: #1e293b;">Granty a dotace</span>
-    </div>
-  </div>
-
   <!-- Stats sekce -->
   <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-bottom: 2rem;">
     <div class="bg-white rounded-lg shadow-md p-6 border-l-4 border-blue-500">

--- a/fdk_cz/templates/hr/dashboard.html
+++ b/fdk_cz/templates/hr/dashboard.html
@@ -4,22 +4,6 @@
 {% block header_subtitle %}Správa zaměstnanců a oddělení{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if organization %}
-      <a href="{% url 'organization_detail' organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">HR Management</span>
-  </div>
-</div>
-
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
   <div class="content-card mb-6">

--- a/fdk_cz/templates/it/dashboard.html
+++ b/fdk_cz/templates/it/dashboard.html
@@ -4,22 +4,6 @@
 {% block header_subtitle %}Správa IT aktiv a incidentů{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">IT Správa</span>
-  </div>
-</div>
-
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
   <div class="content-card mb-6">

--- a/fdk_cz/templates/law/dashboard.html
+++ b/fdk_cz/templates/law/dashboard.html
@@ -6,22 +6,6 @@
 {% block header_subtitle %}Pokročilé nástroje pro právní analýzy, generování dokumentů a právní poradenství{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">AI Právo</span>
-  </div>
-</div>
-
 <div style="max-width: 1400px; margin: 0 auto;">
 
   <!-- Quick Actions for AI Law -->

--- a/fdk_cz/templates/project/new_project.html
+++ b/fdk_cz/templates/project/new_project.html
@@ -6,26 +6,6 @@
 {% block header_subtitle %}Založte nový projekt a vyplňte základní informace{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <a href="{% url 'index_project_cs' %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-      Projekty
-    </a>
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Nový projekt</span>
-  </div>
-</div>
-
 <div style="max-width: 800px; margin: 0 auto;">
   <div class="content-card">
     <form method="POST">

--- a/fdk_cz/templates/project/task_management.html
+++ b/fdk_cz/templates/project/task_management.html
@@ -6,22 +6,6 @@
 {% block header_subtitle %}Přehled a správa osobních, projektových a organizačních úkolů{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Správa úkolů</span>
-  </div>
-</div>
-
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
 
   <!-- Seznam úkolů -->

--- a/fdk_cz/templates/risk/dashboard.html
+++ b/fdk_cz/templates/risk/dashboard.html
@@ -4,22 +4,6 @@
 {% block header_subtitle %}Identifikace, hodnocení a řízení rizik projektů{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if organization %}
-      <a href="{% url 'organization_detail' organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Správa rizik</span>
-  </div>
-</div>
-
 <div class="max-w-6xl mx-auto">
   <!-- Actions -->
   <div class="content-card mb-6">

--- a/fdk_cz/templates/warehouse/all_stores.html
+++ b/fdk_cz/templates/warehouse/all_stores.html
@@ -6,22 +6,6 @@
 {% block header_subtitle %}{% trans "Přehled všech skladů" %}{% endblock %}
 
 {% block content %}
-<!-- Breadcrumbs -->
-<div style="margin-bottom: 1.5rem; background: linear-gradient(to right, #eff6ff, #eef2ff); border: 2px solid #bfdbfe; border-radius: 8px; padding: 1rem;">
-  <div style="display: flex; align-items: center; gap: 0.5rem; font-size: 0.875rem; flex-wrap: wrap;">
-    <span style="color: #64748b;">📍 Kontext:</span>
-    {% if current_organization %}
-      <a href="{% url 'organization_detail' current_organization.organization_id %}" style="color: #3b82f6; text-decoration: none; font-weight: 500;">
-        {{ current_organization.name }}
-      </a>
-    {% else %}
-      <span style="font-weight: 500; color: #1e293b;">Osobní</span>
-    {% endif %}
-    <span style="color: #9ca3af;">→</span>
-    <span style="font-weight: 600; color: #1e293b;">Skladové hospodářství</span>
-  </div>
-</div>
-
 <div style="max-width: 1400px; margin: 0 auto;">
 
   <!-- Actions -->


### PR DESCRIPTION
- Move organization context switcher under Hlavní → Organizace in sidebar
- Add collapsible organization switcher with toggle functionality
- Remove confusing organization context breadcrumbs from all modules
- Keep accounting breadcrumbs with org/personal context for clarity
- Projects already show assignment (personal/org) so context was redundant

Affected: 14 template files including base.html