### PR TITLE
Fix Task title DataError with length validation

### DIFF
--- a/fdk_cz/templates/project/task_management.html
+++ b/fdk_cz/templates/project/task_management.html
@@ -198,7 +198,8 @@
         {% csrf_token %}
         <div class="form-group">
           <label for="title" class="form-label">Název úkolu <span class="required">*</span></label>
-          <input type="text" id="title" name="title" required class="form-control" placeholder="Název úkolu">
+          <input type="text" id="title" name="title" required maxlength="255" class="form-control" placeholder="Název úkolu">
+          <div class="form-help">Maximálně 255 znaků</div>
         </div>
 
         <div class="form-group">

--- a/fdk_cz/views/project.py
+++ b/fdk_cz/views/project.py
@@ -511,6 +511,25 @@ def task_management(request):
         project_id = request.POST.get('project_id')
         organization_id = request.POST.get('organization_id')
 
+        # Validace délky názvu úkolu
+        if not title or len(title.strip()) == 0:
+            messages.error(request, "Název úkolu je povinný.")
+            context_data = {
+                'tasks': user_tasks,
+                'user_organizations': user_organizations,
+                'user_projects': user_projects,
+            }
+            return render(request, 'project/task_management.html', context_data)
+
+        if len(title) > 255:
+            messages.error(request, "Název úkolu je příliš dlouhý. Maximální délka je 255 znaků.")
+            context_data = {
+                'tasks': user_tasks,
+                'user_organizations': user_organizations,
+                'user_projects': user_projects,
+            }
+            return render(request, 'project/task_management.html', context_data)
+
         # Validace - pokud je vybrán kontext projekt/organizace, musí být vybrán i konkrétní projekt/organizace
         if context == 'project' and not project_id:
             messages.error(request, "Pokud vytváříte projektový úkol, musíte vybrat konkrétní projekt.")


### PR DESCRIPTION
- Add maxlength="255" attribute to task title input field
- Add backend validation for title length (max 255 chars)
- Add backend validation for empty/whitespace-only titles
- Display helpful message about character limit