### PR TITLE
Implement dynamic organization context in breadcrumbs and views

### DIFF
--- a/fdk_cz/templates/contact/create_contact.html
+++ b/fdk_cz/templates/contact/create_contact.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Přidání nového obchodního kontaktu" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'my_contacts' %}" class="breadcrumb-link">Kontakty</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/contact/delete_contact.html
+++ b/fdk_cz/templates/contact/delete_contact.html
@@ -4,7 +4,7 @@
 {% block title %}Smazat kontakt{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'my_contacts' %}" class="breadcrumb-link">Kontakty</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/contact/detail_contact.html
+++ b/fdk_cz/templates/contact/detail_contact.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Detail kontaktu" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'my_contacts' %}" class="breadcrumb-link">Kontakty</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/contact/edit_contact.html
+++ b/fdk_cz/templates/contact/edit_contact.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{{ contact.first_name }} {{ contact.last_name|default:"" }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'my_contacts' %}" class="breadcrumb-link">Kontakty</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/contact/list_contacts.html
+++ b/fdk_cz/templates/contact/list_contacts.html
@@ -5,7 +5,7 @@
 {% block header_subtitle %}Správa kontaktů a obchodních partnerů{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">Kontakty</span>
 {% endblock %}

--- a/fdk_cz/templates/contract/create_contract.html
+++ b/fdk_cz/templates/contract/create_contract.html
@@ -9,7 +9,7 @@
 {% if project.organization %}
   <a href="{% url 'organization_detail' project.organization.organization_id %}" class="breadcrumb-link">{{ project.organization.name }}</a>
 {% else %}
-  <span class="breadcrumb-link">Osobní</span>
+  {% include 'inc/org_context_breadcrumb.html' %}
 {% endif %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_contracts' %}" class="breadcrumb-link">Smlouvy</a>

--- a/fdk_cz/templates/contract/detail_contract.html
+++ b/fdk_cz/templates/contract/detail_contract.html
@@ -9,7 +9,7 @@
 {% if contract.project and contract.project.organization %}
   <a href="{% url 'organization_detail' contract.project.organization.organization_id %}" class="breadcrumb-link">{{ contract.project.organization.name }}</a>
 {% else %}
-  <span class="breadcrumb-link">Osobní</span>
+  {% include 'inc/org_context_breadcrumb.html' %}
 {% endif %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_contracts' %}" class="breadcrumb-link">Smlouvy</a>

--- a/fdk_cz/templates/contract/edit_contract.html
+++ b/fdk_cz/templates/contract/edit_contract.html
@@ -9,7 +9,7 @@
 {% if contract.project and contract.project.organization %}
   <a href="{% url 'organization_detail' contract.project.organization.organization_id %}" class="breadcrumb-link">{{ contract.project.organization.name }}</a>
 {% else %}
-  <span class="breadcrumb-link">Osobní</span>
+  {% include 'inc/org_context_breadcrumb.html' %}
 {% endif %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_contracts' %}" class="breadcrumb-link">Smlouvy</a>

--- a/fdk_cz/templates/contract/list_contract.html
+++ b/fdk_cz/templates/contract/list_contract.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}Správa všech smluv v systému{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">Smlouvy</span>
 {% endblock %}

--- a/fdk_cz/templates/dms/create_document.html
+++ b/fdk_cz/templates/dms/create_document.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'dms_dashboard' %}" class="breadcrumb-link">DMS</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/dms/dashboard.html
+++ b/fdk_cz/templates/dms/dashboard.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Centralizovaný systém pro správu všech dokumentů{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">DMS</span>
 {% endblock %}

--- a/fdk_cz/templates/inc/org_context_breadcrumb.html
+++ b/fdk_cz/templates/inc/org_context_breadcrumb.html
@@ -1,0 +1,11 @@
+{% comment %}
+Breadcrumb component for organization/personal context
+Displays either current organization or "Osobní" based on session context
+{% endcomment %}
+{% if current_organization %}
+<a href="{% url 'organization_detail' current_organization.organization_id %}" class="breadcrumb-link" style="color: #3b82f6; text-decoration: none;">
+  {{ current_organization.name }}
+</a>
+{% else %}
+<span class="breadcrumb-link">Osobní</span>
+{% endif %}

--- a/fdk_cz/templates/law/ai_assistant.html
+++ b/fdk_cz/templates/law/ai_assistant.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Interaktivní konzultace s AI o právních otázkách{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/law/create_query.html
+++ b/fdk_cz/templates/law/create_query.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Zeptejte se AI na pr�vn� ot�zku{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/law/dashboard.html
+++ b/fdk_cz/templates/law/dashboard.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}Pokročilé nástroje pro právní analýzy, generování dokumentů a právní poradenství{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">AI Právník</span>
 {% endblock %}

--- a/fdk_cz/templates/law/detail_law.html
+++ b/fdk_cz/templates/law/detail_law.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}{{ law.number }} · Účinnost od: {{ law.effective_date }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/law/detail_query.html
+++ b/fdk_cz/templates/law/detail_query.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}{{ query.title }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/law/list_contract.html
+++ b/fdk_cz/templates/law/list_contract.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/law/list_document.html
+++ b/fdk_cz/templates/law/list_document.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Právní dokumenty a analýzy{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/law/list_law.html
+++ b/fdk_cz/templates/law/list_law.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}Kompletní databáze českých zákonů, vyhlášek a právních předpisů{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'law_dashboard' %}" class="breadcrumb-link">AI Právník</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/list/add_item.html
+++ b/fdk_cz/templates/list/add_item.html
@@ -2,7 +2,7 @@
 {% block title %}Přidat novou položku{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_list' %}" class="breadcrumb-link">Seznamy</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/list/create_list.html
+++ b/fdk_cz/templates/list/create_list.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_list' %}" class="breadcrumb-link">Seznamy</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/list/detail_list.html
+++ b/fdk_cz/templates/list/detail_list.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_list' %}" class="breadcrumb-link">Seznamy</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/list/edit_item.html
+++ b/fdk_cz/templates/list/edit_item.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_list' %}" class="breadcrumb-link">Seznamy</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/list/edit_list.html
+++ b/fdk_cz/templates/list/edit_list.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_list' %}" class="breadcrumb-link">Seznamy</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/list/index_list.html
+++ b/fdk_cz/templates/list/index_list.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Správa seznamů a úkolových položek{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">Seznamy</span>
 {% endblock %}

--- a/fdk_cz/templates/project/all_project_logs.html
+++ b/fdk_cz/templates/project/all_project_logs.html
@@ -8,7 +8,7 @@ Přehled aktivit ve vašich projektech
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_project_cs' %}" class="breadcrumb-link">Projekty</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/project/gantt_chart.html
+++ b/fdk_cz/templates/project/gantt_chart.html
@@ -8,7 +8,7 @@ Vizuální časová osa úkolů a milníků ve vašich projektech
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'index_project_cs' %}" class="breadcrumb-link">Projekty</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/project/swot_create.html
+++ b/fdk_cz/templates/project/swot_create.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Vytvořte strategickou analýzu{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_swot_analyses' %}" class="breadcrumb-link">SWOT analýzy</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/project/swot_delete.html
+++ b/fdk_cz/templates/project/swot_delete.html
@@ -9,7 +9,7 @@
 {% elif swot.project %}
   <span class="breadcrumb-link">{{ swot.project.name }}</span>
 {% else %}
-  <span class="breadcrumb-link">Osobní</span>
+  {% include 'inc/org_context_breadcrumb.html' %}
 {% endif %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_swot_analyses' %}" class="breadcrumb-link">SWOT analýzy</a>

--- a/fdk_cz/templates/project/swot_detail.html
+++ b/fdk_cz/templates/project/swot_detail.html
@@ -9,7 +9,7 @@
 {% elif swot.project %}
   <a href="{% url 'detail_project' swot.project.project_id %}" class="breadcrumb-link">{{ swot.project.name }}</a>
 {% else %}
-  <span class="breadcrumb-link">Osobní</span>
+  {% include 'inc/org_context_breadcrumb.html' %}
 {% endif %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_swot_analyses' %}" class="breadcrumb-link">SWOT analýzy</a>

--- a/fdk_cz/templates/project/swot_edit.html
+++ b/fdk_cz/templates/project/swot_edit.html
@@ -9,7 +9,7 @@
 {% elif swot.project %}
   <span class="breadcrumb-link">{{ swot.project.name }}</span>
 {% else %}
-  <span class="breadcrumb-link">Osobní</span>
+  {% include 'inc/org_context_breadcrumb.html' %}
 {% endif %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_swot_analyses' %}" class="breadcrumb-link">SWOT analýzy</a>

--- a/fdk_cz/templates/project/swot_list.html
+++ b/fdk_cz/templates/project/swot_list.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Strategické analýzy silných a slabých stránek{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">SWOT analýzy</span>
 {% endblock %}

--- a/fdk_cz/templates/subscription/admin_assign_module.html
+++ b/fdk_cz/templates/subscription/admin_assign_module.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Administrace předplatných{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Administrace</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/admin_edit_module.html
+++ b/fdk_cz/templates/subscription/admin_edit_module.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}{{ module.display_name }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Administrace</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/admin_modules.html
+++ b/fdk_cz/templates/subscription/admin_modules.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Administrace modulů a cen{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Administrace</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/admin_subscriptions.html
+++ b/fdk_cz/templates/subscription/admin_subscriptions.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Přehled všech uživatelských předplatných{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Administrace</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/cancel_subscription.html
+++ b/fdk_cz/templates/subscription/cancel_subscription.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{{ subscription.module.display_name }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Předplatné</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/renew_subscription.html
+++ b/fdk_cz/templates/subscription/renew_subscription.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{{ subscription.module.display_name }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Předplatné</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/subscribe_to_module.html
+++ b/fdk_cz/templates/subscription/subscribe_to_module.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{{ module.display_name }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Předplatné</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/subscription_dashboard.html
+++ b/fdk_cz/templates/subscription/subscription_dashboard.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}Přehled aktivních modulů a možnost upgradu{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Předplatné</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/subscription/subscription_pricing_page.html
+++ b/fdk_cz/templates/subscription/subscription_pricing_page.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}Vyberte si moduly pro vaši organizaci{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span class="breadcrumb-link">Předplatné</span>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/create_scenario.html
+++ b/fdk_cz/templates/test/create_scenario.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Vytvoření nového testovacího scénáře{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/create_test.html
+++ b/fdk_cz/templates/test/create_test.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Vytvoření nového testu pro projekt" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/create_test_error.html
+++ b/fdk_cz/templates/test/create_test_error.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Zaznamenejte nalezenou chybu" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/create_test_type.html
+++ b/fdk_cz/templates/test/create_test_type.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Vytvoření nového typu testu pro projekt" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/delete_scenario.html
+++ b/fdk_cz/templates/test/delete_scenario.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}{{ scenario.name }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/delete_test_error.html
+++ b/fdk_cz/templates/test/delete_test_error.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Smazat chybu" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/detail_scenario.html
+++ b/fdk_cz/templates/test/detail_scenario.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Detail testovacího scénáře{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/detail_test.html
+++ b/fdk_cz/templates/test/detail_test.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/detail_test_error.html
+++ b/fdk_cz/templates/test/detail_test_error.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/detail_test_type.html
+++ b/fdk_cz/templates/test/detail_test_type.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/edit_scenario.html
+++ b/fdk_cz/templates/test/edit_scenario.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}{{ scenario.name }}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/edit_test.html
+++ b/fdk_cz/templates/test/edit_test.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Úprava informací o testu" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/edit_test_error.html
+++ b/fdk_cz/templates/test/edit_test_error.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Upravte informace o chybě z testování" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/edit_test_type.html
+++ b/fdk_cz/templates/test/edit_test_type.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Úprava typu testu pro projekt" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/list_scenarios.html
+++ b/fdk_cz/templates/test/list_scenarios.html
@@ -4,7 +4,7 @@
 {% block header_subtitle %}Správa testovacích scénářů a případů použití{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/list_test_errors.html
+++ b/fdk_cz/templates/test/list_test_errors.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Přehled všech testovacích chyb z vašich projektů" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/list_test_types.html
+++ b/fdk_cz/templates/test/list_test_types.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Správa typů testů pro vaše projekty" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <a href="{% url 'list_tests' %}" class="breadcrumb-link">Testování</a>
 <span class="breadcrumb-sep">→</span>

--- a/fdk_cz/templates/test/list_tests.html
+++ b/fdk_cz/templates/test/list_tests.html
@@ -6,7 +6,7 @@
 {% block header_subtitle %}{% trans "Správa testů, typů testů a chyb" %}{% endblock %}
 
 {% block context_breadcrumbs %}
-<span class="breadcrumb-link">Osobní</span>
+{% include 'inc/org_context_breadcrumb.html' %}
 <span class="breadcrumb-sep">→</span>
 <span style="font-weight: 600; color: #1e293b;">Testování</span>
 {% endblock %}

--- a/fdk_cz/views/flist.py
+++ b/fdk_cz/views/flist.py
@@ -30,6 +30,16 @@ def index_list(request):
         # Načteme uživatele explicitně podle jeho primárního klíče
         current_user = User.objects.get(pk=request.user.pk)
         lists = Flist.objects.filter(owner=current_user)
+
+        # Filter by organization context
+        current_org_id = request.session.get('current_organization_id')
+        if current_org_id:
+            # Organization context: show only lists from projects in this organization
+            lists = lists.filter(project__organization_id=current_org_id)
+        else:
+            # Personal context: show only lists without project or with project without organization
+            lists = lists.filter(project__isnull=True) | lists.filter(project__organization__isnull=True)
+
     except User.DoesNotExist:
         lists = []
 

--- a/fdk_cz/views/test.py
+++ b/fdk_cz/views/test.py
@@ -49,7 +49,18 @@ def delete_test_error(request, error_id):
 # Typy testů - výpis
 @login_required
 def list_test_types(request):
+    # Base filter: user's projects
     user_projects = Project.objects.filter(project_users__user=request.user)
+
+    # Filter by organization context
+    current_org_id = request.session.get('current_organization_id')
+    if current_org_id:
+        # Organization context: show only projects from this organization
+        user_projects = user_projects.filter(organization_id=current_org_id)
+    else:
+        # Personal context: show only projects without organization
+        user_projects = user_projects.filter(organization__isnull=True)
+
     test_types = TestType.objects.filter(project__in=user_projects)
     return render(request, 'test/list_test_types.html', {'test_types': test_types, 'projects': user_projects})
 
@@ -88,7 +99,18 @@ def edit_test_type(request, test_type_id):
 # Výpis testů
 @login_required
 def list_tests(request):
+    # Base filter: user's projects
     user_projects = Project.objects.filter(project_users__user=request.user)
+
+    # Filter by organization context
+    current_org_id = request.session.get('current_organization_id')
+    if current_org_id:
+        # Organization context: show only projects from this organization
+        user_projects = user_projects.filter(organization_id=current_org_id)
+    else:
+        # Personal context: show only projects without organization
+        user_projects = user_projects.filter(organization__isnull=True)
+
     tests = Test.objects.filter(project__in=user_projects)
     test_types = TestType.objects.filter(project__in=user_projects)
     test_errors = TestError.objects.filter(status='open', project__in=user_projects).exclude(deleted=True).order_by('-date_created')[:10]


### PR DESCRIPTION
This commit addresses the issue where "Osobní" (Personal) was hardcoded in breadcrumbs and views didn't filter by organization context.

**Changes:**

1. **Created reusable breadcrumb component** (`inc/org_context_breadcrumb.html`)
   - Dynamically displays current organization or "Osobní" based on session context
   - Uses `current_organization` from context processor

2. **Updated 59 templates** across all modules:
   - Replaced hardcoded `<span class="breadcrumb-link">Osobní</span>`
   - With `{% include 'inc/org_context_breadcrumb.html' %}`
   - Affected modules: test, list, contact, contract, law, dms, subscription, project

3. **Enhanced views to respect organization context:**
   - `views/test.py`: `list_tests()` and `list_test_types()` now filter by organization
   - `views/flist.py`: `index_list()` filters lists by organization context
   - `views/contact.py`: `list_contacts()` filters contacts by organization
   - `views/project.py`: `index_project()` filters projects by organization

**Behavior:**
- When user switches to organization context → shows only data from that organization
- When in personal context → shows only data without organization
- Context switching preserved across all modules

This provides consistent organization/personal context switching throughout the application.