### PR TITLE
Implement comprehensive roles and permissions system

### DIFF
--- a/ROLES_PERMISSIONS_DEPLOYMENT.md
+++ b/ROLES_PERMISSIONS_DEPLOYMENT.md
@@ -1,0 +1,342 @@
+# 🔐 Deployment Guide: Comprehensive Roles & Permissions System
+
+**Datum:** 2025-11-27
+**Branch:** `claude/standardize-project-menu-01WXhZ1aj22HukucJ2JiJmRR`
+
+---
+
+## ✅ Co bylo implementováno:
+
+### 1. **Rozšířený systém rolí a oprávnění**
+
+Systém nyní podporuje tři úrovně rolí:
+- **Projektové role** (project_owner, project_admin, project_manager, atd.)
+- **Organizační role** (organization_owner, organization_admin, organization_member, organization_viewer)
+- **Modulové role** (module_manager, module_editor, module_contributor, module_viewer)
+
+### 2. **Nové databázové modely**
+
+#### Organizační role:
+- `OrganizationRole` - definice rolí v organizaci
+- `OrganizationPermission` - oprávnění na úrovni organizace
+- `OrganizationRolePermission` - vazební tabulka
+- `OrganizationMembership` - změněna z CharField na ForeignKey
+
+#### Modulové role:
+- `ModuleRole` - role pro jednotlivé moduly
+- `ModulePermission` - oprávnění v modulech (read, write, delete, manage)
+- `ModuleRolePermission` - vazební tabulka
+- `ModuleAccess` - přístup uživatele k modulu v rámci projektu/organizace
+
+#### Projektové role - rozšířeno:
+- Přidáno pole `description` pro lepší popis rolí
+- Nové role: project_owner, project_controller, project_stakeholder, project_manager
+
+### 3. **Management command**
+- Aktualizován `init_roles` pro inicializaci všech rolí a oprávnění
+
+---
+
+## 📋 DEPLOYMENT INSTRUCTIONS
+
+### Krok 1: Aktualizovat kód
+
+```bash
+cd /var/www/fdk.cz
+
+# Fetch a checkout
+git fetch origin
+git checkout claude/standardize-project-menu-01WXhZ1aj22HukucJ2JiJmRR
+git pull origin claude/standardize-project-menu-01WXhZ1aj22HukucJ2JiJmRR
+```
+
+### Krok 2: Aktivovat virtuální prostředí
+
+```bash
+source /var/www/fdk_app/fdk_env/bin/activate  # Upravit podle skutečné cesty
+```
+
+### Krok 3: Spustit migrace
+
+```bash
+cd /var/www/fdk.cz
+
+# Spustit migrace ve správném pořadí
+python manage.py migrate fdk_cz 0017_comprehensive_roles_permissions
+```
+
+### Krok 4: Inicializovat role a oprávnění
+
+**DŮLEŽITÉ:** Tento krok MUSÍ proběhnout PŘED migrací 0018!
+
+```bash
+python manage.py init_roles
+```
+
+Tento příkaz vytvoří:
+- ✅ 8 projektových rolí s 18 oprávněními
+- ✅ 4 organizační role s 9 oprávněními
+- ✅ 4 modulové role s 4 oprávněními
+
+### Krok 5: Dokončit migrace
+
+```bash
+# Migrovat existující OrganizationMembership data
+python manage.py migrate fdk_cz 0018_migrate_organization_membership_roles
+
+# Finalizovat OrganizationMembership
+python manage.py migrate fdk_cz 0019_finalize_organization_membership
+
+# Nebo spustit všechny zbývající migrace najednou
+python manage.py migrate
+```
+
+### Krok 6: Restartovat aplikaci
+
+```bash
+# Pro gunicorn
+sudo systemctl restart gunicorn
+
+# Nebo pro Apache
+sudo systemctl restart apache2
+
+# Nebo pro development server
+# Ctrl+C a znovu python manage.py runserver
+```
+
+---
+
+## 🔍 Ověření
+
+Po deployment ověřte:
+
+```bash
+# 1. Zkontrolujte, že všechny role byly vytvořeny
+python manage.py shell
+>>> from fdk_cz.models import ProjectRole, OrganizationRole, ModuleRole
+>>> ProjectRole.objects.count()  # Mělo by být 8
+>>> OrganizationRole.objects.count()  # Mělo by být 4
+>>> ModuleRole.objects.count()  # Mělo by být 4
+>>> exit()
+
+# 2. Zkontrolujte databázové tabulky
+python manage.py dbshell
+SELECT COUNT(*) FROM FDK_roles;  -- Projektové role
+SELECT COUNT(*) FROM FDK_organization_roles;  -- Organizační role
+SELECT COUNT(*) FROM FDK_module_roles;  -- Modulové role
+\q
+```
+
+---
+
+## 📊 Matice oprávnění
+
+### Projektové role
+
+| Role | View | Edit | Delete | Manage Users | Manage Budget | Create Tasks | Reports |
+|------|------|------|--------|--------------|---------------|--------------|---------|
+| **project_owner** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **project_admin** | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **project_manager** | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ |
+| **project_controller** | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ |
+| **project_editor** | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **project_contributor** | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **project_viewer** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| **project_stakeholder** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+
+### Organizační role
+
+| Role | View | Edit | Delete | Manage Members | Create Projects | Manage Billing |
+|------|------|------|--------|----------------|-----------------|----------------|
+| **organization_owner** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **organization_admin** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ |
+| **organization_member** | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ |
+| **organization_viewer** | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+### Modulové role
+
+| Role | Read | Write | Delete | Manage |
+|------|------|-------|--------|--------|
+| **module_manager** | ✅ | ✅ | ✅ | ✅ |
+| **module_editor** | ✅ | ✅ | ✅ | ❌ |
+| **module_contributor** | ✅ | ✅ | ❌ | ❌ |
+| **module_viewer** | ✅ | ❌ | ❌ | ❌ |
+
+---
+
+## 🎯 Použití v kódu
+
+### Kontrola oprávnění v projektu
+
+```python
+from fdk_cz.models import ProjectUser, ProjectRolePermission
+
+def user_has_project_permission(user, project, permission_name):
+    """
+    Zkontroluje, zda má uživatel v projektu dané oprávnění.
+    """
+    try:
+        project_user = ProjectUser.objects.get(user=user, project=project)
+        return ProjectRolePermission.objects.filter(
+            role=project_user.role,
+            permission__permission_name=permission_name
+        ).exists()
+    except ProjectUser.DoesNotExist:
+        return False
+
+# Použití
+if user_has_project_permission(request.user, project, 'can_edit_project'):
+    # Uživatel může editovat projekt
+    pass
+```
+
+### Kontrola oprávnění v organizaci
+
+```python
+from fdk_cz.models import OrganizationMembership, OrganizationRolePermission
+
+def user_has_org_permission(user, organization, permission_name):
+    """
+    Zkontroluje, zda má uživatel v organizaci dané oprávnění.
+    """
+    try:
+        membership = OrganizationMembership.objects.get(
+            user=user,
+            organization=organization
+        )
+        return OrganizationRolePermission.objects.filter(
+            role=membership.role,
+            permission__permission_name=permission_name
+        ).exists()
+    except OrganizationMembership.DoesNotExist:
+        return False
+
+# Použití
+if user_has_org_permission(request.user, org, 'can_manage_members'):
+    # Uživatel může spravovat členy organizace
+    pass
+```
+
+### Kontrola oprávnění v modulu
+
+```python
+from fdk_cz.models import ModuleAccess, ModuleRolePermission
+
+def user_has_module_permission(user, module_name, project=None, organization=None, permission_name='can_read'):
+    """
+    Zkontroluje, zda má uživatel oprávnění k modulu.
+    """
+    try:
+        access = ModuleAccess.objects.get(
+            user=user,
+            module_name=module_name,
+            project=project,
+            organization=organization
+        )
+        return ModuleRolePermission.objects.filter(
+            role=access.role,
+            permission__permission_name=permission_name
+        ).exists()
+    except ModuleAccess.DoesNotExist:
+        return False
+
+# Použití
+if user_has_module_permission(request.user, 'warehouse', project=project, permission_name='can_write'):
+    # Uživatel může zapisovat do skladu
+    pass
+```
+
+### Dekorátor pro view
+
+```python
+from django.core.exceptions import PermissionDenied
+from functools import wraps
+
+def require_project_permission(permission_name):
+    """
+    Dekorátor pro view, který vyžaduje projektové oprávnění.
+    Předpokládá, že view má parametr project_id.
+    """
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapper(request, project_id, *args, **kwargs):
+            from fdk_cz.models import Project
+            project = Project.objects.get(project_id=project_id)
+
+            if not user_has_project_permission(request.user, project, permission_name):
+                raise PermissionDenied("Nemáte oprávnění k této akci.")
+
+            return view_func(request, project_id, *args, **kwargs)
+        return wrapper
+    return decorator
+
+# Použití
+@require_project_permission('can_edit_project')
+def edit_project(request, project_id):
+    # View pro editaci projektu
+    pass
+```
+
+---
+
+## ⚠️ Důležité poznámky
+
+1. **Pořadí migrací je kritické!**
+   Nejprve 0017 → pak init_roles → pak 0018 → nakonec 0019
+
+2. **Starý systém rolí**
+   Staré hard-coded role v OrganizationMembership ('admin', 'member', 'viewer') budou automaticky migrovány na nové role
+
+3. **Migrace existujících dat**
+   Všechny existující organizační členství budou migrována:
+   - 'admin' → 'organization_admin'
+   - 'member' → 'organization_member'
+   - 'viewer' → 'organization_viewer'
+
+4. **Nové projekty**
+   Pro nové projekty byste měli přiřazovat role jako 'project_owner', 'project_admin', atd.
+
+5. **ModuleAccess**
+   Modulové přístupy je potřeba přiřazovat manuálně podle potřeby. Nejsou automaticky vytvářeny.
+
+---
+
+## 🐛 Troubleshooting
+
+### Problém: Migrace 0018 selhává
+
+**Řešení:** Ujistěte se, že jste spustili `init_roles` PŘED migrací 0018.
+
+```bash
+python manage.py init_roles
+python manage.py migrate fdk_cz 0018
+```
+
+### Problém: Chybí některé role
+
+**Řešení:** Spusťte init_roles znovu - příkaz je idempotentní.
+
+```bash
+python manage.py init_roles
+```
+
+### Problém: OrganizationMembership.role je NULL
+
+**Řešení:** Zkontrolujte, že migrace 0018 proběhla správně.
+
+```bash
+python manage.py migrate fdk_cz 0018 --fake  # pokud data už byla migrována manuálně
+```
+
+---
+
+## 📞 Podpora
+
+Pro otázky nebo problémy kontaktujte:
+- GitHub Issues: [eKultura/fdk.cz](https://github.com/eKultura/fdk.cz/issues)
+- Email: support@fdk.cz (upravit podle skutečnosti)
+
+---
+
+**Vytvořil:** Claude
+**Datum:** 2025-11-27

--- a/ROLES_PERMISSIONS_GUIDE.md
+++ b/ROLES_PERMISSIONS_GUIDE.md
@@ -1,0 +1,413 @@
+# 🔐 Průvodce systémem rolí a oprávnění
+
+## 📖 Úvod
+
+Systém FDK.cz používá třístupňový systém rolí a oprávnění:
+1. **Organizační role** - oprávnění na úrovni celé organizace
+2. **Projektové role** - oprávnění na úrovni konkrétního projektu
+3. **Modulové role** - granulární oprávnění pro jednotlivé moduly (sklad, kontakty, faktury, atd.)
+
+---
+
+## 🏢 Organizační role
+
+### organization_owner (Vlastník organizace)
+**Kdy použít:** Pro zakládatele nebo majitele organizace
+
+**Oprávnění:**
+- ✅ Kompletní kontrola nad organizací
+- ✅ Může smazat organizaci
+- ✅ Spravuje všechny členy
+- ✅ Spravuje fakturaci
+- ✅ Přístup ke všem projektům
+- ✅ Může vytvářet a spravovat projekty
+
+**Příklad použití:**
+```python
+from fdk_cz.models import OrganizationMembership, OrganizationRole
+
+# Přiřadit uživatele jako ownera organizace
+owner_role = OrganizationRole.objects.get(role_name='organization_owner')
+OrganizationMembership.objects.create(
+    user=user,
+    organization=organization,
+    role=owner_role
+)
+```
+
+---
+
+### organization_admin (Administrátor organizace)
+**Kdy použít:** Pro hlavní správce, kteří pomáhají řídit organizaci
+
+**Oprávnění:**
+- ✅ Upravuje nastavení organizace
+- ✅ Spravuje členy (přidává/odebírá)
+- ✅ Vytváří a spravuje projekty
+- ✅ Přístup ke všem projektům
+- ❌ Nemůže smazat organizaci
+- ❌ Nemůže spravovat fakturaci
+
+**Rozdíl oproti owner:**
+Nemůže smazat organizaci ani spravovat platby/fakturaci.
+
+---
+
+### organization_member (Člen organizace)
+**Kdy použít:** Pro běžné zaměstnance nebo spolupracovníky
+
+**Oprávnění:**
+- ✅ Vidí organizaci a její projekty
+- ✅ Může vytvářet nové projekty
+- ❌ Nemůže upravovat organizaci
+- ❌ Nemůže spravovat členy
+
+**Příklad:**
+Vývojář, který pracuje na projektech organizace.
+
+---
+
+### organization_viewer (Pozorovatel organizace)
+**Kdy použít:** Pro externí spolupracovníky, auditora, apod.
+
+**Oprávnění:**
+- ✅ Vidí organizaci
+- ✅ Vidí všechny projekty (read-only)
+- ❌ Nemůže vytvářet projekty
+- ❌ Nemůže nic upravovat
+
+**Příklad:**
+Externí auditor, který potřebuje nahlédnout do projektů.
+
+---
+
+## 📁 Projektové role
+
+### project_owner (Vlastník projektu)
+**Kdy použít:** Pro osobu zodpovědnou za projekt
+
+**Oprávnění:**
+- ✅ Kompletní kontrola nad projektem
+- ✅ Může smazat projekt
+- ✅ Spravuje uživatele projektu
+- ✅ Spravuje rozpočet
+- ✅ Všechna oprávnění k úkolům, dokumentům, milníkům
+
+---
+
+### project_admin (Administrátor projektu)
+**Kdy použít:** Pro zástupce PM nebo vedoucí týmu
+
+**Oprávnění:**
+- ✅ Upravuje projekt
+- ✅ Spravuje uživatele
+- ✅ Spravuje rozpočet
+- ✅ Všechna oprávnění k obsahu
+- ❌ Nemůže smazat projekt
+
+**Rozdíl oproti owner:**
+Nemůže smazat projekt.
+
+---
+
+### project_manager (Projektový manažer)
+**Kdy použít:** Pro projektového manažera, který řídí projekt
+
+**Oprávnění:**
+- ✅ Upravuje projekt
+- ✅ Spravuje rozpočet
+- ✅ Vytváří a přiřazuje úkoly
+- ✅ Spravuje milníky
+- ✅ Vytváří reporty
+- ❌ Nemůže spravovat uživatele
+
+**Typický use case:**
+PM, který řídí projekt, ale nepřidává/neodebírá členy týmu.
+
+---
+
+### project_controller (Kontrolor projektu)
+**Kdy použít:** Pro finanční kontrolora nebo auditora
+
+**Oprávnění:**
+- ✅ Vidí projekt (read-only)
+- ✅ Spravuje rozpočet
+- ✅ Vytváří reporty
+- ❌ Nemůže upravovat obsah projektu
+
+**Typický use case:**
+Finanční controller, který sleduje čerpání rozpočtu.
+
+---
+
+### project_editor (Editor projektu)
+**Kdy použít:** Pro aktivní členy týmu
+
+**Oprávnění:**
+- ✅ Upravuje projekt
+- ✅ Vytváří a upravuje úkoly
+- ✅ Vytváří a upravuje dokumenty
+- ✅ Vytváří a upravuje milníky
+- ❌ Nemůže spravovat rozpočet
+- ❌ Nemůže spravovat uživatele
+
+**Typický use case:**
+Vývojář nebo designer, který aktivně pracuje na projektu.
+
+---
+
+### project_contributor (Přispěvatel)
+**Kdy použít:** Pro příležitostné přispěvatele
+
+**Oprávnění:**
+- ✅ Vidí projekt
+- ✅ Vytváří úkoly
+- ✅ Upravuje úkoly (pravděpodobně jen své)
+- ✅ Vytváří dokumenty
+- ❌ Nemůže upravovat projekt
+- ❌ Nemůže mazat
+
+**Typický use case:**
+Externí freelancer, který přispívá do projektu.
+
+---
+
+### project_viewer (Pozorovatel)
+**Kdy použít:** Pro osoby, které potřebují jen sledovat projekt
+
+**Oprávnění:**
+- ✅ Vidí projekt (read-only)
+- ✅ Vidí reporty
+- ❌ Nemůže nic upravovat
+
+**Typický use case:**
+Klient nebo stakeholder, který chce sledovat postup.
+
+---
+
+### project_stakeholder (Stakeholder)
+**Kdy použít:** Pro klíčové stakeholdery projektu
+
+**Oprávnění:**
+- ✅ Vidí projekt (read-only)
+- ✅ Vidí reporty
+- ❌ Nemůže nic upravovat
+
+**Rozdíl oproti viewer:**
+Logické oddělení - stakeholder je významnější osoba (investor, klient, vedení).
+
+---
+
+## 🔧 Modulové role
+
+Modulové role se přiřazují **pro konkrétní modul** (warehouse, contact, invoice, atd.) v rámci **projektu nebo organizace**.
+
+### Dostupné moduly:
+- `warehouse` - Sklad
+- `contact` - Kontakty
+- `invoice` - Faktury
+- `task` - Úkoly
+- `document` - Dokumenty
+- `milestone` - Milníky
+
+### module_manager (Správce modulu)
+**Oprávnění:**
+- ✅ Read (čtení)
+- ✅ Write (zápis)
+- ✅ Delete (mazání)
+- ✅ Manage (správa - např. nastavení, export, import)
+
+**Příklad:**
+Jan má roli "module_manager" pro modul "warehouse" v projektu X.
+→ Jan může dělat cokoliv se skladem v projektu X.
+
+---
+
+### module_editor (Editor modulu)
+**Oprávnění:**
+- ✅ Read
+- ✅ Write
+- ✅ Delete
+- ❌ Manage
+
+**Příklad:**
+Petra má roli "module_editor" pro modul "invoice" v organizaci Y.
+→ Petra může vytvářet, upravovat a mazat faktury v organizaci Y, ale nemůže měnit nastavení fakturace.
+
+---
+
+### module_contributor (Přispěvatel modulu)
+**Oprávnění:**
+- ✅ Read
+- ✅ Write
+- ❌ Delete
+- ❌ Manage
+
+**Příklad:**
+Tomáš má roli "module_contributor" pro modul "contact" v projektu Z.
+→ Tomáš může přidávat a upravovat kontakty, ale nemůže je mazat.
+
+---
+
+### module_viewer (Pozorovatel modulu)
+**Oprávnění:**
+- ✅ Read
+- ❌ Write
+- ❌ Delete
+- ❌ Manage
+
+**Příklad:**
+Marie má roli "module_viewer" pro modul "warehouse" v projektu X.
+→ Marie vidí sklad, ale nemůže nic měnit.
+
+---
+
+## 🎯 Praktické příklady použití
+
+### Příklad 1: Startupová firma
+
+**Organizace:** "TechStartup s.r.o."
+
+**Členové:**
+- Jan (Founder) → `organization_owner`
+- Petra (CTO) → `organization_admin`
+- Tomáš (Developer) → `organization_member`
+- Marie (Investor) → `organization_viewer`
+
+**Projekt:** "MVP Aplikace"
+
+**Členové projektu:**
+- Jan → `project_owner`
+- Petra → `project_manager`
+- Tomáš → `project_editor`
+- Marie → `project_stakeholder`
+
+**Modulové přístupy:**
+- Tomáš má `module_manager` pro modul `task` (spravuje úkoly)
+- Petra má `module_manager` pro modul `warehouse` (spravuje sklad)
+- Marie má `module_viewer` pro modul `invoice` (vidí faktury)
+
+---
+
+### Příklad 2: Agentura s klienty
+
+**Organizace:** "WebAgency s.r.o."
+
+**Členové:**
+- Alice (Owner) → `organization_owner`
+- Bob (PM) → `organization_admin`
+- Carol (Designer) → `organization_member`
+- David (Developer) → `organization_member`
+
+**Projekt:** "Web pro Klienta A"
+
+**Členové projektu:**
+- Alice → `project_owner`
+- Bob → `project_manager`
+- Carol → `project_editor`
+- David → `project_editor`
+- Klient → `project_viewer`
+
+**Modulové přístupy:**
+- Bob má `module_manager` pro všechny moduly
+- Carol má `module_editor` pro `task` a `document`
+- David má `module_editor` pro `task`
+- Klient má `module_viewer` pro `document` a `milestone`
+
+---
+
+### Příklad 3: Vládní/veřejný projekt s auditorem
+
+**Organizace:** "MěstoXY"
+
+**Projekt:** "Digitalizace úřadu"
+
+**Členové:**
+- Vedoucí IT → `project_owner`
+- Projektový manažer → `project_manager`
+- Finanční controller → `project_controller` (sleduje rozpočet)
+- Externí auditor → `project_viewer`
+- Subdodavatelé → `project_contributor`
+
+**Modulové přístupy:**
+- Controller má `module_manager` pro modul `invoice`
+- Auditor má `module_viewer` pro všechny moduly
+- Subdodavatelé mají `module_contributor` pro modul `task`
+
+---
+
+## 💡 Tipy a best practices
+
+### 1. Princip minimálních oprávnění
+Vždy přiřazujte **nejnižší možnou roli**, která je pro uživatele potřebná.
+
+### 2. Kombinace rolí
+Uživatel může mít:
+- 1 roli v organizaci
+- Různé role v různých projektech
+- Různé modulové role v různých projektech/organizacích
+
+### 3. Hierarchie oprávnění
+```
+organization_owner > project_owner > module_manager
+```
+
+Pokud má uživatel `organization_owner`, měl by mít přístup ke všem projektům.
+Pokud má `project_owner`, měl by mít přístup ke všem modulům projektu.
+
+### 4. Kdy použít modulové role?
+Modulové role jsou užitečné, když:
+- Chcete udělit přístup jen k určité části projektu
+- Máte externího spolupracovníka, který pracuje jen se skladem
+- Chcete omezit přístup k citlivým datům (faktury)
+
+### 5. Organizace vs. Projekt
+- **Organizace** = firma, instituce
+- **Projekt** = konkrétní zakázka, iniciativa
+
+Uživatel může být členem organizace, ale nemusí být přiřazen ke všem projektům.
+
+---
+
+## 🔒 Bezpečnostní doporučení
+
+1. **Pravidelný audit oprávnění**
+   Pravidelně kontrolujte, kdo má jaké role, zejména `owner` a `admin`.
+
+2. **Odebírejte oprávnění po odchodu**
+   Když člověk opustí projekt/organizaci, ihned odeberte jeho členství.
+
+3. **Dokumentujte důvody**
+   Zaznamenávejte, proč byla určitá role přidělena.
+
+4. **Dvě oči vidí více**
+   Pro kritické operace (mazání projektu, fakturace) mějte vždy více než jednoho ownera.
+
+---
+
+## 📝 FAQ
+
+**Q: Jaký je rozdíl mezi project_viewer a project_stakeholder?**
+A: Funkčně jsou stejné (read-only přístup). Stakeholder je logické oddělení pro významné osoby (investor, klient, vedení).
+
+**Q: Může mít uživatel více rolí v jednom projektu?**
+A: Ne, každý uživatel má v projektu právě jednu roli (ProjectUser.role).
+
+**Q: Co když potřebuji custom oprávnění?**
+A: Můžete vytvořit novou roli a přiřadit jí potřebná oprávnění, nebo použít modulové role pro granulární kontrolu.
+
+**Q: Jak změnit roli uživatele?**
+A: Upravte ProjectUser nebo OrganizationMembership objekt a změňte hodnotu `role`.
+
+```python
+project_user = ProjectUser.objects.get(user=user, project=project)
+new_role = ProjectRole.objects.get(role_name='project_editor')
+project_user.role = new_role
+project_user.save()
+```
+
+---
+
+**Vytvořil:** Claude
+**Datum:** 2025-11-27
+**Verze:** 1.0

--- a/fdk_cz/management/commands/init_roles.py
+++ b/fdk_cz/management/commands/init_roles.py
@@ -1,78 +1,142 @@
 # fdk_cz/management/commands/init_roles.py
 
 from django.core.management.base import BaseCommand
-from fdk_cz.models import ProjectRole, ProjectPermission, ProjectRolePermission
+from fdk_cz.models import (
+    # Projektové role
+    ProjectRole, ProjectPermission, ProjectRolePermission,
+    # Organizační role
+    OrganizationRole, OrganizationPermission, OrganizationRolePermission,
+    # Modulové role
+    ModuleRole, ModulePermission, ModuleRolePermission
+)
 
 class Command(BaseCommand):
-    help = 'Inicializovat projektové role a oprávnění'
+    help = 'Inicializovat všechny role a oprávnění (projekt, organizace, moduly)'
 
     def handle(self, *args, **kwargs):
         self.stdout.write(self.style.SUCCESS('🔐 Inicializace rolí a oprávnění...'))
+        self.stdout.write('')
 
-        # Definice oprávnění
-        permissions_data = [
-            'can_view_project',
-            'can_edit_project',
-            'can_delete_project',
-            'can_manage_users',
-            'can_create_tasks',
-            'can_edit_tasks',
-            'can_delete_tasks',
-            'can_create_documents',
-            'can_delete_documents',
-            'can_create_milestones',
-            'can_edit_milestones',
+        # ================================================================
+        # 1. PROJEKTOVÉ ROLE A OPRÁVNĚNÍ
+        # ================================================================
+        self.stdout.write(self.style.SUCCESS('📁 Projektové role a oprávnění'))
+        self.stdout.write('-' * 60)
+
+        # Definice projektových oprávnění
+        project_permissions_data = [
+            ('can_view_project', 'Prohlížení projektu'),
+            ('can_edit_project', 'Úprava projektu'),
+            ('can_delete_project', 'Smazání projektu'),
+            ('can_manage_users', 'Správa uživatelů projektu'),
+            ('can_manage_settings', 'Správa nastavení projektu'),
+            ('can_manage_budget', 'Správa rozpočtu'),
+            ('can_create_tasks', 'Vytváření úkolů'),
+            ('can_edit_tasks', 'Úprava úkolů'),
+            ('can_delete_tasks', 'Mazání úkolů'),
+            ('can_assign_tasks', 'Přiřazování úkolů'),
+            ('can_create_documents', 'Vytváření dokumentů'),
+            ('can_edit_documents', 'Úprava dokumentů'),
+            ('can_delete_documents', 'Mazání dokumentů'),
+            ('can_create_milestones', 'Vytváření milníků'),
+            ('can_edit_milestones', 'Úprava milníků'),
+            ('can_delete_milestones', 'Mazání milníků'),
+            ('can_view_reports', 'Prohlížení reportů'),
+            ('can_create_reports', 'Vytváření reportů'),
         ]
 
-        # Vytvořit oprávnění
-        permissions = {}
-        for perm_name in permissions_data:
+        # Vytvořit projektová oprávnění
+        project_permissions = {}
+        for perm_name, perm_desc in project_permissions_data:
             perm, created = ProjectPermission.objects.get_or_create(
-                permission_name=perm_name
+                permission_name=perm_name,
+                defaults={'description': perm_desc}
             )
-            permissions[perm_name] = perm
+            project_permissions[perm_name] = perm
             if created:
                 self.stdout.write(f'  ✅ Vytvořeno oprávnění: {perm_name}')
 
-        # Definice rolí s jejich oprávněními
-        roles_data = {
-            'Administrator': [
-                'can_view_project',
-                'can_edit_project',
-                'can_delete_project',
-                'can_manage_users',
-                'can_create_tasks',
-                'can_edit_tasks',
-                'can_delete_tasks',
-                'can_create_documents',
-                'can_delete_documents',
-                'can_create_milestones',
-                'can_edit_milestones',
-            ],
-            'Manager': [
-                'can_view_project',
-                'can_edit_project',
-                'can_create_tasks',
-                'can_edit_tasks',
-                'can_create_documents',
-                'can_create_milestones',
-                'can_edit_milestones',
-            ],
-            'Developer': [
-                'can_view_project',
-                'can_create_tasks',
-                'can_edit_tasks',
-                'can_create_documents',
-            ],
-            'Viewer': [
-                'can_view_project',
-            ],
+        # Definice projektových rolí s jejich oprávněními
+        project_roles_data = {
+            'project_owner': {
+                'description': 'Vlastník projektu - plná kontrola',
+                'permissions': [
+                    'can_view_project', 'can_edit_project', 'can_delete_project',
+                    'can_manage_users', 'can_manage_settings', 'can_manage_budget',
+                    'can_create_tasks', 'can_edit_tasks', 'can_delete_tasks', 'can_assign_tasks',
+                    'can_create_documents', 'can_edit_documents', 'can_delete_documents',
+                    'can_create_milestones', 'can_edit_milestones', 'can_delete_milestones',
+                    'can_view_reports', 'can_create_reports',
+                ]
+            },
+            'project_admin': {
+                'description': 'Administrátor projektu',
+                'permissions': [
+                    'can_view_project', 'can_edit_project',
+                    'can_manage_users', 'can_manage_settings', 'can_manage_budget',
+                    'can_create_tasks', 'can_edit_tasks', 'can_delete_tasks', 'can_assign_tasks',
+                    'can_create_documents', 'can_edit_documents', 'can_delete_documents',
+                    'can_create_milestones', 'can_edit_milestones', 'can_delete_milestones',
+                    'can_view_reports', 'can_create_reports',
+                ]
+            },
+            'project_manager': {
+                'description': 'Projektový manažer',
+                'permissions': [
+                    'can_view_project', 'can_edit_project',
+                    'can_manage_budget',
+                    'can_create_tasks', 'can_edit_tasks', 'can_assign_tasks',
+                    'can_create_documents', 'can_edit_documents',
+                    'can_create_milestones', 'can_edit_milestones',
+                    'can_view_reports', 'can_create_reports',
+                ]
+            },
+            'project_controller': {
+                'description': 'Kontrolor projektu',
+                'permissions': [
+                    'can_view_project',
+                    'can_manage_budget',
+                    'can_view_reports', 'can_create_reports',
+                ]
+            },
+            'project_editor': {
+                'description': 'Editor projektu',
+                'permissions': [
+                    'can_view_project', 'can_edit_project',
+                    'can_create_tasks', 'can_edit_tasks',
+                    'can_create_documents', 'can_edit_documents',
+                    'can_create_milestones', 'can_edit_milestones',
+                ]
+            },
+            'project_contributor': {
+                'description': 'Přispěvatel',
+                'permissions': [
+                    'can_view_project',
+                    'can_create_tasks', 'can_edit_tasks',
+                    'can_create_documents',
+                ]
+            },
+            'project_viewer': {
+                'description': 'Pozorovatel',
+                'permissions': [
+                    'can_view_project',
+                    'can_view_reports',
+                ]
+            },
+            'project_stakeholder': {
+                'description': 'Stakeholder',
+                'permissions': [
+                    'can_view_project',
+                    'can_view_reports',
+                ]
+            },
         }
 
-        # Vytvořit role
-        for role_name, perm_names in roles_data.items():
+        # Vytvořit projektové role
+        for role_name, role_data in project_roles_data.items():
             role, created = ProjectRole.objects.get_or_create(
-                role_name=role_name
+                role_name=role_name,
+                defaults={'description': role_data['description']}
             )
 
             if created:
@@ -81,14 +145,182 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.WARNING(f'  🔄 Role již existuje: {role_name}'))
 
             # Přiřadit oprávnění k roli
-            for perm_name in perm_names:
+            for perm_name in role_data['permissions']:
                 ProjectRolePermission.objects.get_or_create(
                     role=role,
-                    permission=permissions[perm_name]
+                    permission=project_permissions[perm_name]
                 )
 
         self.stdout.write('')
+        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(project_roles_data)} projektových rolí'))
+        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(project_permissions_data)} projektových oprávnění'))
+        self.stdout.write('')
+
+        # ================================================================
+        # 2. ORGANIZAČNÍ ROLE A OPRÁVNĚNÍ
+        # ================================================================
+        self.stdout.write(self.style.SUCCESS('🏢 Organizační role a oprávnění'))
+        self.stdout.write('-' * 60)
+
+        # Definice organizačních oprávnění
+        org_permissions_data = [
+            ('can_view_organization', 'Prohlížení organizace'),
+            ('can_edit_organization', 'Úprava organizace'),
+            ('can_delete_organization', 'Smazání organizace'),
+            ('can_manage_members', 'Správa členů organizace'),
+            ('can_create_projects', 'Vytváření projektů'),
+            ('can_manage_projects', 'Správa projektů'),
+            ('can_view_all_projects', 'Prohlížení všech projektů'),
+            ('can_manage_billing', 'Správa fakturace'),
+            ('can_manage_settings', 'Správa nastavení organizace'),
+        ]
+
+        # Vytvořit organizační oprávnění
+        org_permissions = {}
+        for perm_name, perm_desc in org_permissions_data:
+            perm, created = OrganizationPermission.objects.get_or_create(
+                permission_name=perm_name,
+                defaults={'description': perm_desc}
+            )
+            org_permissions[perm_name] = perm
+            if created:
+                self.stdout.write(f'  ✅ Vytvořeno oprávnění: {perm_name}')
+
+        # Definice organizačních rolí
+        org_roles_data = {
+            'organization_owner': {
+                'description': 'Vlastník organizace',
+                'permissions': [
+                    'can_view_organization', 'can_edit_organization', 'can_delete_organization',
+                    'can_manage_members', 'can_create_projects', 'can_manage_projects',
+                    'can_view_all_projects', 'can_manage_billing', 'can_manage_settings',
+                ]
+            },
+            'organization_admin': {
+                'description': 'Administrátor organizace',
+                'permissions': [
+                    'can_view_organization', 'can_edit_organization',
+                    'can_manage_members', 'can_create_projects', 'can_manage_projects',
+                    'can_view_all_projects', 'can_manage_settings',
+                ]
+            },
+            'organization_member': {
+                'description': 'Člen organizace',
+                'permissions': [
+                    'can_view_organization',
+                    'can_create_projects',
+                    'can_view_all_projects',
+                ]
+            },
+            'organization_viewer': {
+                'description': 'Pozorovatel organizace',
+                'permissions': [
+                    'can_view_organization',
+                    'can_view_all_projects',
+                ]
+            },
+        }
+
+        # Vytvořit organizační role
+        for role_name, role_data in org_roles_data.items():
+            role, created = OrganizationRole.objects.get_or_create(
+                role_name=role_name,
+                defaults={'description': role_data['description']}
+            )
+
+            if created:
+                self.stdout.write(self.style.SUCCESS(f'  ✅ Vytvořena role: {role_name}'))
+            else:
+                self.stdout.write(self.style.WARNING(f'  🔄 Role již existuje: {role_name}'))
+
+            # Přiřadit oprávnění k roli
+            for perm_name in role_data['permissions']:
+                OrganizationRolePermission.objects.get_or_create(
+                    role=role,
+                    permission=org_permissions[perm_name]
+                )
+
+        self.stdout.write('')
+        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(org_roles_data)} organizačních rolí'))
+        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(org_permissions_data)} organizačních oprávnění'))
+        self.stdout.write('')
+
+        # ================================================================
+        # 3. MODULOVÉ ROLE A OPRÁVNĚNÍ
+        # ================================================================
+        self.stdout.write(self.style.SUCCESS('🔧 Modulové role a oprávnění'))
+        self.stdout.write('-' * 60)
+
+        # Definice modulových oprávnění
+        module_permissions_data = [
+            ('can_read', 'Čtení dat modulu'),
+            ('can_write', 'Zápis dat do modulu'),
+            ('can_delete', 'Mazání dat v modulu'),
+            ('can_manage', 'Správa modulu'),
+        ]
+
+        # Vytvořit modulová oprávnění
+        module_permissions = {}
+        for perm_name, perm_desc in module_permissions_data:
+            perm, created = ModulePermission.objects.get_or_create(
+                permission_name=perm_name,
+                defaults={'description': perm_desc}
+            )
+            module_permissions[perm_name] = perm
+            if created:
+                self.stdout.write(f'  ✅ Vytvořeno oprávnění: {perm_name}')
+
+        # Definice modulových rolí
+        module_roles_data = {
+            'module_manager': {
+                'description': 'Správce modulu - plný přístup',
+                'permissions': ['can_read', 'can_write', 'can_delete', 'can_manage']
+            },
+            'module_editor': {
+                'description': 'Editor modulu - čtení, zápis, mazání',
+                'permissions': ['can_read', 'can_write', 'can_delete']
+            },
+            'module_contributor': {
+                'description': 'Přispěvatel modulu - čtení a zápis',
+                'permissions': ['can_read', 'can_write']
+            },
+            'module_viewer': {
+                'description': 'Pozorovatel modulu - pouze čtení',
+                'permissions': ['can_read']
+            },
+        }
+
+        # Vytvořit modulové role
+        for role_name, role_data in module_roles_data.items():
+            role, created = ModuleRole.objects.get_or_create(
+                role_name=role_name,
+                defaults={'description': role_data['description']}
+            )
+
+            if created:
+                self.stdout.write(self.style.SUCCESS(f'  ✅ Vytvořena role: {role_name}'))
+            else:
+                self.stdout.write(self.style.WARNING(f'  🔄 Role již existuje: {role_name}'))
+
+            # Přiřadit oprávnění k roli
+            for perm_name in role_data['permissions']:
+                ModuleRolePermission.objects.get_or_create(
+                    role=role,
+                    permission=module_permissions[perm_name]
+                )
+
+        self.stdout.write('')
+        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(module_roles_data)} modulových rolí'))
+        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(module_permissions_data)} modulových oprávnění'))
+        self.stdout.write('')
+
+        # ================================================================
+        # SHRNUTÍ
+        # ================================================================
         self.stdout.write(self.style.SUCCESS('='*60))
-        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(roles_data)} rolí'))
-        self.stdout.write(self.style.SUCCESS(f'✅ Vytvořeno {len(permissions_data)} oprávnění'))
+        self.stdout.write(self.style.SUCCESS('✅ INICIALIZACE DOKONČENA'))
+        self.stdout.write(self.style.SUCCESS('='*60))
+        self.stdout.write(self.style.SUCCESS(f'📁 Projektové: {len(project_roles_data)} rolí, {len(project_permissions_data)} oprávnění'))
+        self.stdout.write(self.style.SUCCESS(f'🏢 Organizační: {len(org_roles_data)} rolí, {len(org_permissions_data)} oprávnění'))
+        self.stdout.write(self.style.SUCCESS(f'🔧 Modulové: {len(module_roles_data)} rolí, {len(module_permissions_data)} oprávnění'))
         self.stdout.write(self.style.SUCCESS('='*60))

--- a/fdk_cz/migrations/0017_comprehensive_roles_permissions.py
+++ b/fdk_cz/migrations/0017_comprehensive_roles_permissions.py
@@ -1,0 +1,208 @@
+# Generated manually for comprehensive roles and permissions system
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Comprehensive roles and permissions system:
+    - Adds description fields to ProjectRole and ProjectPermission
+    - Creates OrganizationRole, OrganizationPermission, OrganizationRolePermission
+    - Migrates OrganizationMembership from CharField to ForeignKey for role
+    - Creates ModuleRole, ModulePermission, ModuleRolePermission, ModuleAccess
+    """
+
+    dependencies = [
+        ('fdk_cz', '0016_merge_20251123_1324'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # ================================================================
+        # 1. Add description fields to existing Project tables
+        # ================================================================
+        migrations.AddField(
+            model_name='projectrole',
+            name='description',
+            field=models.TextField(blank=True, help_text='Stručný popis role', null=True),
+        ),
+        migrations.AddField(
+            model_name='projectpermission',
+            name='description',
+            field=models.TextField(blank=True, null=True),
+        ),
+
+        # ================================================================
+        # 2. Create Organization Role tables
+        # ================================================================
+        migrations.CreateModel(
+            name='OrganizationRole',
+            fields=[
+                ('role_id', models.AutoField(primary_key=True, serialize=False)),
+                ('role_name', models.CharField(max_length=255, unique=True)),
+                ('description', models.TextField(blank=True, help_text='Stručný popis role', null=True)),
+            ],
+            options={
+                'db_table': 'FDK_organization_roles',
+                'verbose_name': 'Organizační role',
+                'verbose_name_plural': 'Organizační role',
+            },
+        ),
+        migrations.CreateModel(
+            name='OrganizationPermission',
+            fields=[
+                ('permission_id', models.AutoField(primary_key=True, serialize=False)),
+                ('permission_name', models.CharField(max_length=255, unique=True)),
+                ('description', models.TextField(blank=True, null=True)),
+            ],
+            options={
+                'db_table': 'FDK_organization_permissions',
+                'verbose_name': 'Organizační oprávnění',
+                'verbose_name_plural': 'Organizační oprávnění',
+            },
+        ),
+        migrations.CreateModel(
+            name='OrganizationRolePermission',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('permission', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='fdk_cz.organizationpermission')),
+                ('role', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='permissions', to='fdk_cz.organizationrole')),
+            ],
+            options={
+                'db_table': 'FDK_organization_role_permissions',
+                'unique_together': {('role', 'permission')},
+            },
+        ),
+
+        # ================================================================
+        # 3. Create Module Role tables
+        # ================================================================
+        migrations.CreateModel(
+            name='ModuleRole',
+            fields=[
+                ('role_id', models.AutoField(primary_key=True, serialize=False)),
+                ('role_name', models.CharField(max_length=255, unique=True)),
+                ('description', models.TextField(blank=True, help_text='Stručný popis role', null=True)),
+            ],
+            options={
+                'db_table': 'FDK_module_roles',
+                'verbose_name': 'Modulová role',
+                'verbose_name_plural': 'Modulové role',
+            },
+        ),
+        migrations.CreateModel(
+            name='ModulePermission',
+            fields=[
+                ('permission_id', models.AutoField(primary_key=True, serialize=False)),
+                ('permission_name', models.CharField(max_length=255, unique=True)),
+                ('description', models.TextField(blank=True, null=True)),
+            ],
+            options={
+                'db_table': 'FDK_module_permissions',
+                'verbose_name': 'Modulové oprávnění',
+                'verbose_name_plural': 'Modulová oprávnění',
+            },
+        ),
+        migrations.CreateModel(
+            name='ModuleRolePermission',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('permission', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='fdk_cz.modulepermission')),
+                ('role', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='permissions', to='fdk_cz.modulerole')),
+            ],
+            options={
+                'db_table': 'FDK_module_role_permissions',
+                'unique_together': {('role', 'permission')},
+            },
+        ),
+        migrations.CreateModel(
+            name='ModuleAccess',
+            fields=[
+                ('access_id', models.AutoField(primary_key=True, serialize=False)),
+                ('module_name', models.CharField(
+                    choices=[
+                        ('warehouse', 'Sklad'),
+                        ('contact', 'Kontakty'),
+                        ('invoice', 'Faktury'),
+                        ('task', 'Úkoly'),
+                        ('document', 'Dokumenty'),
+                        ('milestone', 'Milníky'),
+                    ],
+                    max_length=50
+                )),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('organization', models.ForeignKey(
+                    blank=True,
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='module_accesses',
+                    to='fdk_cz.organization'
+                )),
+                ('project', models.ForeignKey(
+                    blank=True,
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='module_accesses',
+                    to='fdk_cz.project'
+                )),
+                ('role', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='accesses',
+                    to='fdk_cz.modulerole'
+                )),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='module_accesses',
+                    to=settings.AUTH_USER_MODEL
+                )),
+            ],
+            options={
+                'db_table': 'FDK_module_access',
+                'verbose_name': 'Modulový přístup',
+                'verbose_name_plural': 'Modulové přístupy',
+                'unique_together': {('user', 'module_name', 'project', 'organization')},
+            },
+        ),
+
+        # ================================================================
+        # 4. Migrate OrganizationMembership.role from CharField to ForeignKey
+        # ================================================================
+        # This is a complex migration that requires:
+        # 1. Create temporary default role
+        # 2. Rename old role field
+        # 3. Add new role field as ForeignKey
+        # 4. Migrate data
+        # 5. Remove old field
+
+        # Step 1: Rename the old role field
+        migrations.RenameField(
+            model_name='organizationmembership',
+            old_name='role',
+            new_name='role_old',
+        ),
+
+        # Step 2: Add new role field as ForeignKey (nullable for now)
+        migrations.AddField(
+            model_name='organizationmembership',
+            name='role',
+            field=models.ForeignKey(
+                null=True,  # Temporarily nullable
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='memberships',
+                to='fdk_cz.organizationrole'
+            ),
+        ),
+
+        # Step 3: Data migration will be handled separately or in production
+        # The init_roles command should be run first to create the roles
+
+        # Note: After running init_roles, you'll need to manually update existing memberships:
+        # UPDATE FDK_organization_membership SET role_id = (
+        #   SELECT role_id FROM FDK_organization_roles WHERE role_name = 'organization_' || role_old
+        # );
+
+        # Step 4: After data migration, make role non-nullable and remove role_old
+        # This will be done in a follow-up migration after data is migrated
+    ]

--- a/fdk_cz/migrations/0018_migrate_organization_membership_roles.py
+++ b/fdk_cz/migrations/0018_migrate_organization_membership_roles.py
@@ -1,0 +1,80 @@
+# Data migration for OrganizationMembership role conversion
+
+from django.db import migrations
+
+
+def migrate_organization_roles(apps, schema_editor):
+    """
+    Migrate existing OrganizationMembership roles from CharField to ForeignKey.
+    Maps old role values to new OrganizationRole objects.
+    """
+    OrganizationMembership = apps.get_model('fdk_cz', 'OrganizationMembership')
+    OrganizationRole = apps.get_model('fdk_cz', 'OrganizationRole')
+
+    # Mapping from old CharField values to new role names
+    role_mapping = {
+        'admin': 'organization_admin',
+        'member': 'organization_member',
+        'viewer': 'organization_viewer',
+    }
+
+    # Get or create roles if they don't exist (should be created by init_roles)
+    for old_value, new_name in role_mapping.items():
+        role, created = OrganizationRole.objects.get_or_create(
+            role_name=new_name,
+            defaults={'description': f'Migrated from {old_value}'}
+        )
+
+        # Update all memberships with this old role value
+        memberships = OrganizationMembership.objects.filter(role_old=old_value)
+        for membership in memberships:
+            membership.role = role
+            membership.save()
+
+    # Handle any memberships that might have unexpected role values
+    unmatched = OrganizationMembership.objects.filter(role__isnull=True)
+    if unmatched.exists():
+        # Default to organization_member for any unmatched roles
+        default_role = OrganizationRole.objects.get(role_name='organization_member')
+        for membership in unmatched:
+            membership.role = default_role
+            membership.save()
+
+
+def reverse_migration(apps, schema_editor):
+    """
+    Reverse migration: copy role back to role_old
+    """
+    OrganizationMembership = apps.get_model('fdk_cz', 'OrganizationMembership')
+
+    role_reverse_mapping = {
+        'organization_admin': 'admin',
+        'organization_member': 'member',
+        'organization_viewer': 'viewer',
+        'organization_owner': 'admin',  # Map owner back to admin
+    }
+
+    for membership in OrganizationMembership.objects.all():
+        if membership.role:
+            role_name = membership.role.role_name
+            old_value = role_reverse_mapping.get(role_name, 'member')
+            membership.role_old = old_value
+            membership.save()
+
+
+class Migration(migrations.Migration):
+    """
+    Data migration to convert OrganizationMembership.role from CharField to ForeignKey.
+    This should be run AFTER init_roles command has been executed.
+    """
+
+    dependencies = [
+        ('fdk_cz', '0017_comprehensive_roles_permissions'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_organization_roles,
+            reverse_code=reverse_migration
+        ),
+    ]

--- a/fdk_cz/migrations/0019_finalize_organization_membership.py
+++ b/fdk_cz/migrations/0019_finalize_organization_membership.py
@@ -1,0 +1,42 @@
+# Final migration to clean up OrganizationMembership
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    """
+    Finalize OrganizationMembership migration:
+    - Make role field non-nullable
+    - Remove old role_old field
+    - Add unique_together constraint
+    """
+
+    dependencies = [
+        ('fdk_cz', '0018_migrate_organization_membership_roles'),
+    ]
+
+    operations = [
+        # Remove the old role_old field
+        migrations.RemoveField(
+            model_name='organizationmembership',
+            name='role_old',
+        ),
+
+        # Alter role field to be non-nullable and add the proper constraint
+        migrations.AlterField(
+            model_name='organizationmembership',
+            name='role',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='memberships',
+                to='fdk_cz.organizationrole'
+            ),
+        ),
+
+        # Add unique_together constraint (if not already present)
+        migrations.AlterUniqueTogether(
+            name='organizationmembership',
+            unique_together={('user', 'organization')},
+        ),
+    ]


### PR DESCRIPTION
This commit implements a three-tier role and permission system:
- Organization roles (owner, admin, member, viewer)
- Project roles (owner, admin, manager, controller, editor, contributor, viewer, stakeholder)
- Module roles (manager, editor, contributor, viewer)

Changes:
- Added OrganizationRole, OrganizationPermission, OrganizationRolePermission models
- Added ModuleRole, ModulePermission, ModuleRolePermission, ModuleAccess models
- Extended ProjectRole and ProjectPermission with description fields
- Migrated OrganizationMembership.role from CharField to ForeignKey
- Updated init_roles command to initialize all roles and permissions
- Created 3 migrations (0017, 0018, 0019) for database schema changes
- Added comprehensive documentation (ROLES_PERMISSIONS_DEPLOYMENT.md, ROLES_PERMISSIONS_GUIDE.md)

Migrations:
- 0017: Create new tables and add description fields
- 0018: Migrate existing OrganizationMembership data
- 0019: Finalize OrganizationMembership by removing old role field

Documentation:
- ROLES_PERMISSIONS_DEPLOYMENT.md: Deployment instructions and troubleshooting
- ROLES_PERMISSIONS_GUIDE.md: User guide with role descriptions and examples