### PR TITLE
Rename conflicting migrations to avoid database conflict

### DIFF
--- a/fdk_cz/migrations/0020_comprehensive_roles_permissions.py
+++ b/fdk_cz/migrations/0020_comprehensive_roles_permissions.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ('fdk_cz', '0016_merge_20251123_1324'),
+        ('fdk_cz', '0017_invoice_created_by_invoice_organization_and_more'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 

--- a/fdk_cz/migrations/0021_migrate_organization_membership_roles.py
+++ b/fdk_cz/migrations/0021_migrate_organization_membership_roles.py
@@ -69,7 +69,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ('fdk_cz', '0017_comprehensive_roles_permissions'),
+        ('fdk_cz', '0020_comprehensive_roles_permissions'),
     ]
 
     operations = [

--- a/fdk_cz/migrations/0022_finalize_organization_membership.py
+++ b/fdk_cz/migrations/0022_finalize_organization_membership.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ('fdk_cz', '0018_migrate_organization_membership_roles'),
+        ('fdk_cz', '0021_migrate_organization_membership_roles'),
     ]
 
     operations = [


### PR DESCRIPTION
Renamed comprehensive roles migrations from 0017-0019 to 0020-0022 to avoid conflict with existing 0017_invoice migration in database.

Changes:
- 0017_comprehensive_roles_permissions.py -> 0020_comprehensive_roles_permissions.py
- 0018_migrate_organization_membership_roles.py -> 0021_migrate_organization_membership_roles.py
- 0019_finalize_organization_membership.py -> 0022_finalize_organization_membership.py

Updated dependencies in all renamed migrations to maintain proper chain.