### PR TITLE
Fix: Use string reference for Organization ForeignKey

### DIFF
--- a/fdk_cz/models/project.py
+++ b/fdk_cz/models/project.py
@@ -254,7 +254,7 @@ class ProjectTask(models.Model):
     creator = models.ForeignKey(User, on_delete=models.CASCADE, related_name='created_tasks', db_column='creator_id')
     assigned = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='assigned_tasks', db_column='assigned_id')
     project = models.ForeignKey(Project, on_delete=models.SET_NULL, null=True, related_name='tasks', db_column='project_id')
-    organization = models.ForeignKey(Organization, on_delete=models.SET_NULL, null=True, blank=True, related_name='tasks', db_column='organization_id')
+    organization = models.ForeignKey('Organization', on_delete=models.SET_NULL, null=True, blank=True, related_name='tasks', db_column='organization_id')
     due_date = models.DateField(null=True, blank=True, db_column='due_date')
     created = models.DateTimeField(null=True, blank=True, db_column='created')
     parent = models.ForeignKey('self', on_delete=models.CASCADE, null=True, blank=True, related_name='subtasks', db_column='parent_id')
@@ -637,7 +637,7 @@ class AccountingContext(models.Model):
                             related_name='accounting_contexts',
                             db_column='user_id',
                             help_text='Vlastník účetnictví')
-    organization = models.ForeignKey(Organization, on_delete=models.CASCADE,
+    organization = models.ForeignKey('Organization', on_delete=models.CASCADE,
                                     null=True, blank=True,
                                     related_name='accounting_contexts',
                                     db_column='organization_id',


### PR DESCRIPTION
Changed Organization to 'Organization' on lines 257 and 640 to avoid NameError during model loading. String references allow forward declarations in Django models.