### PR TITLE
Fix: Repair context switching and add visual context indicator

### DIFF
--- a/fdk_cz/context_processors.py
+++ b/fdk_cz/context_processors.py
@@ -257,8 +257,9 @@ def organization_context(request):
             user_organizations.append(org)
 
     # Check if user can switch organizations
-    # Superadmins (user.id <= 10) can switch, others cannot
-    can_switch = request.user.id <= 10
+    # Everyone can switch between personal and organization context
+    # VIP users can have multiple organizations
+    can_switch = len(user_organizations) > 0
 
     # Get current organization from session
     current_org_id = request.session.get('current_organization_id')
@@ -278,14 +279,12 @@ def organization_context(request):
             if 'current_organization_id' in request.session:
                 del request.session['current_organization_id']
 
-    # For non-superadmin users with exactly one organization, set it automatically
-    if not can_switch and not current_organization and len(user_organizations) == 1:
-        current_organization = user_organizations[0]
-        request.session['current_organization_id'] = current_organization.organization_id
+    # Default to personal context (no automatic org selection)
+    # Users explicitly choose organization or stay in personal context
 
     return {
         'current_organization': current_organization,
-        'user_organizations': user_organizations if can_switch else [],
+        'user_organizations': user_organizations,
         'is_personal_context': current_organization is None,
         'can_switch_organizations': can_switch
     }

--- a/fdk_cz/templates/project/index_project.html
+++ b/fdk_cz/templates/project/index_project.html
@@ -11,6 +11,36 @@
 
 {% block content %}
 
+<!-- Context Indicator -->
+<div style="margin-bottom: 1.5rem; padding: 0.75rem 1rem; background: {% if current_organization %}linear-gradient(to right, #dbeafe, #eff6ff){% else %}linear-gradient(to right, #d1fae5, #ecfdf5){% endif %}; border-left: 4px solid {% if current_organization %}#3b82f6{% else %}#10b981{% endif %}; border-radius: 8px; display: flex; justify-content: space-between; align-items: center;">
+  <div>
+    <span style="font-size: 0.875rem; color: #64748b; font-weight: 500;">📍 Aktuální kontext:</span>
+    <span style="font-size: 1rem; font-weight: 700; color: {% if current_organization %}#1e40af{% else %}#065f46{% endif %}; margin-left: 0.5rem;">
+      {% if current_organization %}
+        🏢 {{ current_organization.name }}
+      {% else %}
+        👤 Osobní
+      {% endif %}
+    </span>
+  </div>
+  {% if can_switch_organizations %}
+  <div style="display: flex; gap: 0.5rem;">
+    {% if current_organization %}
+      <a href="{% url 'set_personal_context' %}" style="padding: 0.375rem 0.75rem; background: white; border: 2px solid #10b981; color: #10b981; border-radius: 6px; font-size: 0.875rem; font-weight: 600; text-decoration: none; transition: all 0.2s;" onmouseover="this.style.background='#10b981'; this.style.color='white';" onmouseout="this.style.background='white'; this.style.color='#10b981';">
+        👤 Přepnout na osobní
+      </a>
+    {% endif %}
+    {% for org in user_organizations %}
+      {% if not current_organization or org.organization_id != current_organization.organization_id %}
+      <a href="{% url 'set_organization_context' org.organization_id %}" style="padding: 0.375rem 0.75rem; background: white; border: 2px solid #3b82f6; color: #3b82f6; border-radius: 6px; font-size: 0.875rem; font-weight: 600; text-decoration: none; transition: all 0.2s;" onmouseover="this.style.background='#3b82f6'; this.style.color='white';" onmouseout="this.style.background='white'; this.style.color='#3b82f6';">
+        🏢 {{ org.name|truncatewords:3 }}
+      </a>
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>
+
 <!-- Quick Actions Bar -->
 <div style="display: flex; gap: 0.75rem; margin-bottom: 2rem; flex-wrap: wrap;">
   {% with url="new_project_cs" icon="📁" label="Nový projekt" %}

--- a/sql_migrations/create_user_profile_table.sql
+++ b/sql_migrations/create_user_profile_table.sql
@@ -1,0 +1,26 @@
+-- SQL migrace pro vytvoření tabulky FDK_user_profile
+-- Spustit na produkční databázi
+
+CREATE TABLE IF NOT EXISTS `FDK_user_profile` (
+    `id` bigint NOT NULL AUTO_INCREMENT,
+    `user_id` int NOT NULL,
+    `is_vip` tinyint(1) NOT NULL DEFAULT 0 COMMENT 'VIP uživatelé mají vyšší limity projektů',
+    `created_at` datetime(6) NOT NULL,
+    `updated_at` datetime(6) NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `user_id` (`user_id`),
+    CONSTRAINT `FDK_user_profile_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `auth_user` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='Profily uživatelů s VIP statusem';
+
+-- Vytvoříme profily pro všechny existující uživatele
+INSERT IGNORE INTO `FDK_user_profile` (`user_id`, `is_vip`, `created_at`, `updated_at`)
+SELECT
+    id,
+    0,
+    NOW(),
+    NOW()
+FROM `auth_user`;
+
+-- Zaznamenat migraci jako provedenou
+INSERT INTO `django_migrations` (`app`, `name`, `applied`)
+VALUES ('fdk_cz', '0023_add_user_profile', NOW());


### PR DESCRIPTION
**Issues Fixed:**
1. Projects not visible - users couldn't see their projects until selecting org
2. No clear indication of current context (personal vs organization)
3. Automatic organization assignment was hiding personal projects
4. Database error: FDK_user_profile table doesn't exist

**Changes:**

**Context Processor (fdk_cz/context_processors.py):**
- Remove automatic organization assignment for single-org users
- Default to personal context instead of auto-selecting organization
- Allow all users (not just superadmins) to switch between contexts
- Users now explicitly choose organization or stay in personal view

**Project List UI (templates/project/index_project.html):**
- Add prominent context indicator showing current mode:
  - 👤 Personal (green) or 🏢 Organization (blue)
- Add quick-switch buttons to change context without menu
- Visual feedback with hover effects and color coding

**Database Migration (sql_migrations/):**
- Create SQL file for FDK_user_profile table creation
- Includes FK constraint to auth_user
- Auto-creates profiles for existing users
- Records migration in django_migrations table

**Behavior:**
- Default: Personal context (all user projects visible)
- Organization context: Only projects from selected org
- Clear visual indication at all times
- Easy switching between contexts

Run SQL migration: `mysql fdk < sql_migrations/create_user_profile_table.sql`

Refs #263