### PR TITLE
Fix: Context indicator now properly shows selected organization

### DIFF
--- a/fdk_cz/context_processors.py
+++ b/fdk_cz/context_processors.py
@@ -269,7 +269,10 @@ def organization_context(request):
         try:
             # Verify user has access to this organization
             org = Organization.objects.get(organization_id=current_org_id)
-            if org in user_organizations:
+
+            # Check access by comparing organization IDs (more reliable than object comparison)
+            org_ids = [o.organization_id for o in user_organizations]
+            if org.organization_id in org_ids:
                 current_organization = org
             else:
                 # User doesn't have access, clear session


### PR DESCRIPTION
- Changed organization access check from object comparison to ID comparison
- Fixes issue where context indicator showed "Osobní" even after switching to organization
- The filter was working (projects filtered correctly), but visual indicator failed due to unreliable object comparison in Django ORM